### PR TITLE
fix(machine): a machine still starting is waited for, so a cold-attached NIC gets its resolver (#694)

### DIFF
--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -84,6 +84,14 @@ type Incus struct {
 	// second half is the conformance suite's job and cannot be faked.
 	runner func(ctx context.Context, args ...string) ([]byte, error)
 
+	// resolverPoll and resolverWait override how the resolver path waits for a
+	// guest to be ready to be asked, and are only ever set by a test. The
+	// budget is measured — a guest first names its network unit around fourteen
+	// seconds after the poweron (#694) — so a suite that could not shorten it
+	// would pay that measurement on every case.
+	resolverPoll time.Duration
+	resolverWait time.Duration
+
 	// statPath replaces the filesystem lookup Verify uses to decide whether the
 	// OVN northbound socket exists, and is only ever set by a test. Existence,
 	// never a connection: the socket is root-owned (srwxr-x--- root root) and

--- a/internal/core/machine/incus_resolver.go
+++ b/internal/core/machine/incus_resolver.go
@@ -289,7 +289,7 @@ func (d *Incus) setGuestResolver(ctx context.Context, machine, device string) {
 	// reconfiguration.
 	d.writeGuestResolverConfig(ctx, machine, iface)
 
-	deadline := time.Now().Add(guestResolverWait)
+	deadline := time.Now().Add(d.resolverBudget())
 	for {
 		_, err := d.run(ctx, "exec", machine, "--", "resolvectl", "dns", iface, d.resolver())
 		if err == nil {
@@ -322,7 +322,7 @@ func (d *Incus) setGuestResolver(ctx context.Context, machine, device string) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(guestResolverPoll):
+			case <-time.After(d.resolverInterval()):
 			}
 			continue
 		}
@@ -342,13 +342,36 @@ func (d *Incus) setGuestResolver(ctx context.Context, machine, device string) {
 // seconds is not going to.
 const (
 	guestResolverPoll = 500 * time.Millisecond
-	guestResolverWait = 10 * time.Second
+	// Past the measured boot, with margin, and the measurement is the whole
+	// story. Polled every two seconds from the poweron of a cold-attached
+	// machine (2026-09-06), beside the driver's own log:
+	//
+	//	t+2 .. t+40   Error: Instance is not running
+	//	t+42          links=[lo eth0@if182]
+	//	t+44          eth0 -> /run/systemd/network/10-netplan-eth0.network
+	//	driver        gave up after 30s, twelve seconds early
+	//
+	// 10s was the first value here and 30s the second; both gave up before the
+	// container had started. It costs nothing when the guest is quick — the
+	// wait ends the moment it answers — and what it now covers is a boot the
+	// client is already waiting on.
+	guestResolverWait = 90 * time.Second
 )
 
 // guestBusNotReady is the transient half: systemd is there and not listening
 // yet.
 func guestBusNotReady(err error) bool {
-	return strings.Contains(strings.ToLower(err.Error()), "failed to connect to bus")
+	msg := strings.ToLower(err.Error())
+	// Both wordings, and both are quoted from a run rather than remembered:
+	//
+	//	incus exec: Failed to connect system bus: No such file or directory
+	//	Failed to connect to bus: No such file or directory
+	//
+	// Written with the second alone — which is what it was — the first fell
+	// through to the permanent matcher, which accepts "no such file or
+	// directory", and the unit lookup gave up on its first ask against a guest
+	// whose systemd was seconds from being up (#694).
+	return strings.Contains(msg, "failed to connect") && strings.Contains(msg, "bus")
 }
 
 // guestHasNoResolvectl is the permanent half: the binary is absent, which is
@@ -408,9 +431,66 @@ func (d *Incus) writeGuestResolverConfig(ctx context.Context, machine, iface str
 // and silently: a drop-in for a unit that does not exist is a file, not an
 // error.
 func (d *Incus) guestNetworkUnit(ctx context.Context, machine, iface string) string {
+	// Bounded retry, and the budget is measured rather than picked. Polled every
+	// second from the poweron of a machine whose NIC was attached cold
+	// (2026-09-06): the container existed at t+1s and the guest first named a
+	// unit at t+14s. Asked once — which is what this did — settleFirstBoot got
+	// nothing and wrote no drop-in at all, which is #694.
+	deadline := time.Now().Add(d.resolverBudget())
+	for {
+		unit, err := d.readGuestNetworkUnit(ctx, machine, iface)
+		if unit != "" {
+			return unit
+		}
+		// ONLY a failed ask is retried. A networkctl that ANSWERED and named no
+		// unit is an interface networkd manages with none — the `n/a` case —
+		// and waiting on it changes nothing: written the other way, every unit
+		// test whose fake answers nothing paid the whole budget, and this
+		// package went from seconds to ten minutes.
+		//
+		// The transient cases really are failures, measured: before systemd is
+		// up the guest answers `Failed to connect to bus`, and before the link
+		// exists it answers `Interface "eth0" not found.` — both non-zero.
+		if err == nil {
+			return ""
+		}
+		// An image with no networkctl is not waited for either: Alpine answers
+		// once and for good, and the whole budget would be charged to every boot
+		// of it.
+		//
+		// The two transient shapes are recognised FIRST, and that ordering is
+		// the fix rather than a nicety: `Interface "eth0" not found.` and
+		// `networkctl: not found` both carry "not found", so the permanent
+		// matcher accepts the link that has simply not appeared yet. Read that
+		// way, the lookup gives up on a guest that was about to be ready — the
+		// same confusion the bus refusal already cost this file once.
+		if !isNotRunning(err) && !guestBusNotReady(err) && !guestLinkNotThereYet(err, iface) &&
+			guestHasNoNetworkd(err) {
+			return ""
+		}
+		if time.Now().After(deadline) {
+			// Said, not swallowed. A drop-in that was never written is a machine
+			// with no resolver, and this path used to return quietly — which is
+			// how #694 stayed invisible in the log while being obvious in the
+			// guest.
+			d.logger().Warn("the guest never named a network unit, so it has no resolver of ours",
+				"machine", machine, "interface", iface, "waited", d.resolverBudget().String())
+			return ""
+		}
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-time.After(d.resolverInterval()):
+		}
+	}
+}
+
+// readGuestNetworkUnit is one ask, and the answer's three shapes: a unit, an
+// interface networkd manages with none, and a guest not ready to be asked.
+func (d *Incus) readGuestNetworkUnit(ctx context.Context, machine, iface string) (string, error) {
 	out, err := d.run(ctx, "exec", machine, "--", "networkctl", "status", iface)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		_, after, found := strings.Cut(line, "Network File:")
@@ -421,11 +501,11 @@ func (d *Incus) guestNetworkUnit(ctx context.Context, machine, iface string) str
 		// `n/a` is what an unmanaged link answers, and it is a name this would
 		// otherwise happily build a directory for.
 		if path == "" || path == "n/a" {
-			return ""
+			return "", nil
 		}
-		return path[strings.LastIndex(path, "/")+1:]
+		return path[strings.LastIndex(path, "/")+1:], nil
 	}
-	return ""
+	return "", nil
 }
 
 // shellQuote wraps a value for `sh -c`, which is the only place this driver
@@ -437,4 +517,38 @@ func (d *Incus) guestNetworkUnit(ctx context.Context, machine, iface string) str
 // first.
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// resolverBudget and resolverInterval are the two constants above, behind the
+// seams a test sets. Same shape as routePoll and agentPoll, and for the same
+// reason: the budget is a measurement of a real guest, and a unit suite that
+// had to spend it would spend it once per case.
+func (d *Incus) resolverBudget() time.Duration {
+	if d.resolverWait > 0 {
+		return d.resolverWait
+	}
+	return guestResolverWait
+}
+
+func (d *Incus) resolverInterval() time.Duration {
+	if d.resolverPoll > 0 {
+		return d.resolverPoll
+	}
+	return guestResolverPoll
+}
+
+// guestLinkNotThereYet is the other transient shape: systemd is up and the
+// interface has not appeared.
+//
+// Measured wording, not guessed — `incus exec … -- networkctl status eth0` on a
+// container whose NIC is not attached answers `Interface "eth0" not found.`.
+// The interface name is part of the match so that a genuinely absent binary,
+// which says `networkctl: not found`, is not read as a link about to appear.
+//
+// TestALinkThatIsNotThereYetIsWaitedFor fails without this.
+func guestLinkNotThereYet(err error, iface string) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "interface") &&
+		strings.Contains(msg, strings.ToLower(iface)) &&
+		strings.Contains(msg, "not found")
 }

--- a/internal/core/machine/incus_resolver_test.go
+++ b/internal/core/machine/incus_resolver_test.go
@@ -1,8 +1,10 @@
 package machine
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -401,6 +403,219 @@ func TestAResolverThatIsNotAnAddressReachesNoCommand(t *testing.T) {
 	for _, call := range f.commands() {
 		if strings.Contains(call, "exit") || strings.Contains(call, "feint-dns.conf") {
 			t.Fatalf("a resolver that is not an address reached a command line:\n  %q", call)
+		}
+	}
+}
+
+// The unit lookup waits for the guest to be ready to be asked.
+//
+// Measured 2026-09-06 on a machine whose NIC was attached before the poweron,
+// polling every second from the poweron: the container existed at t+1s and the
+// guest first named a unit at t+14s. Asked once — which is what this did —
+// settleFirstBoot got nothing and wrote no drop-in at all, which is #694.
+func TestTheUnitLookupWaitsForTheGuest(t *testing.T) {
+	const answersAt = 3 // the guest is not ready for the first two asks
+	asks := 0
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth0": "Link 2 (eth0): " + DefaultResolver + "\n",
+	}}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		if len(args) >= 5 && args[0] == "exec" && args[3] == "networkctl" && args[4] == "status" {
+			asks++
+			if asks < answersAt {
+				return nil, errors.New(`Failed to connect to bus: No such file or directory`), true
+			}
+			return []byte("    Network File: /run/systemd/network/10-netplan-eth0.network\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	d := newFakeDriver(f)
+	d.OVN = true
+
+	d.setGuestResolver(context.Background(), "srv", "eth0")
+
+	if asks < answersAt {
+		t.Fatalf("the lookup gave up after %d ask(s), before the guest answered at %d", asks, answersAt)
+	}
+	if i := indexOfCall(f, "feint-dns.conf"); i < 0 {
+		t.Fatalf("the guest answered and no drop-in was written:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A guest that never names a unit is SAID, not swallowed.
+//
+// A drop-in that was never written is a machine with no resolver, and this path
+// used to return quietly — which is how #694 stayed invisible in the log while
+// being obvious in the guest.
+func TestAUnitThatNeverAppearsIsSaid(t *testing.T) {
+	var said bytes.Buffer
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth0": "Link 2 (eth0): " + DefaultResolver + "\n",
+	}, fail: map[string]error{
+		"networkctl status": errors.New(`Failed to connect to bus: No such file or directory`),
+	}}
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.Log = slog.New(slog.NewTextHandler(&said, nil))
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
+
+	d.setGuestResolver(context.Background(), "srv", "eth0")
+
+	if !strings.Contains(said.String(), "never named a network unit") {
+		t.Fatalf("a guest that never named a unit was not reported:\n%s", said.String())
+	}
+	// And no drop-in was invented from the absence.
+	if i := indexOfCall(f, "feint-dns.conf"); i >= 0 {
+		t.Errorf("a drop-in was written for a unit nobody named:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A link that is not there yet is waited for; a binary that never will be is
+// not.
+//
+// Both answer with "not found" — `Interface "eth0" not found.` and
+// `networkctl: not found` — and read as the same thing the lookup gives up on a
+// guest that was about to be ready. The same confusion the bus refusal already
+// cost this file once.
+func TestALinkThatIsNotThereYetIsWaitedFor(t *testing.T) {
+	t.Run("the link appears", func(t *testing.T) {
+		const appears = 3
+		asks := 0
+		f := &fakeRuntime{answers: map[string]string{
+			"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+			"resolvectl dns eth0": "Link 2 (eth0): " + DefaultResolver + "\n",
+		}}
+		f.hook = func(_ int, args []string) ([]byte, error, bool) {
+			if len(args) >= 5 && args[0] == "exec" && args[3] == "networkctl" && args[4] == "status" {
+				asks++
+				if asks < appears {
+					return nil, errors.New(`Interface "eth0" not found.`), true
+				}
+				return []byte("    Network File: /run/systemd/network/10-netplan-eth0.network\n"), nil, true
+			}
+			return nil, nil, false
+		}
+		d := newFakeDriver(f)
+		d.OVN = true
+		d.resolverPoll = time.Millisecond
+
+		d.setGuestResolver(context.Background(), "srv", "eth0")
+
+		if asks < appears {
+			t.Fatalf("the lookup gave up after %d ask(s), before the link appeared at %d", asks, appears)
+		}
+		if i := indexOfCall(f, "feint-dns.conf"); i < 0 {
+			t.Fatalf("the link appeared and no drop-in was written:\n%s", strings.Join(f.commands(), "\n"))
+		}
+	})
+
+	t.Run("the binary is absent", func(t *testing.T) {
+		asks := 0
+		f := &fakeRuntime{answers: map[string]string{
+			"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+		}}
+		f.hook = func(_ int, args []string) ([]byte, error, bool) {
+			if len(args) >= 5 && args[0] == "exec" && args[3] == "networkctl" && args[4] == "status" {
+				asks++
+				return nil, errors.New(`sh: networkctl: not found`), true
+			}
+			return nil, nil, false
+		}
+		d := newFakeDriver(f)
+		d.OVN = true
+		d.resolverPoll = time.Millisecond
+		d.resolverWait = 5 * time.Second
+
+		d.setGuestResolver(context.Background(), "srv", "eth0")
+
+		if asks != 1 {
+			t.Fatalf("an image with no networkctl was asked %d times for a binary it does not have, want 1", asks)
+		}
+	})
+}
+
+// A machine that is still starting is waited for.
+//
+// The timeline that settled #694 put the driver's log beside the guest's
+// answers, every two seconds from the poweron of a cold-attached machine
+// (2026-09-06):
+//
+//	t+2 .. t+40   Error: Instance is not running
+//	t+42          links=[lo eth0@if182]
+//	t+44          eth0 -> /run/systemd/network/10-netplan-eth0.network
+//	driver        gave up after 30s, twelve seconds before the guest was ready
+//
+// The guest was never slow to name its unit. The container was not running, and
+// that answer was in none of the transient cases.
+func TestAMachineStillStartingIsWaitedFor(t *testing.T) {
+	const running = 4 // not running for the first three asks
+	asks := 0
+	f := &fakeRuntime{answers: map[string]string{
+		"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+		"resolvectl dns eth0": "Link 2 (eth0): " + DefaultResolver + "\n",
+	}}
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		if len(args) >= 5 && args[0] == "exec" && args[3] == "networkctl" && args[4] == "status" {
+			asks++
+			if asks < running {
+				return nil, errors.New("Error: Instance is not running"), true
+			}
+			return []byte("    Network File: /run/systemd/network/10-netplan-eth0.network\n"), nil, true
+		}
+		return nil, nil, false
+	}
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.resolverPoll = time.Millisecond
+
+	d.setGuestResolver(context.Background(), "srv", "eth0")
+
+	if asks < running {
+		t.Fatalf("the lookup gave up after %d ask(s), before the machine was running at %d", asks, running)
+	}
+	if i := indexOfCall(f, "feint-dns.conf"); i < 0 {
+		t.Fatalf("the machine came up and no drop-in was written:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// A bus refusal is recognised in both wordings.
+//
+// Quoted from runs rather than remembered, which is the whole point: the matcher
+// looked for `failed to connect to bus` and the guest says `Failed to connect
+// system bus`. With a "to" the message does not carry, the refusal fell through
+// to the permanent matcher — which accepts "no such file or directory" — and the
+// unit lookup gave up on its first ask against a guest seconds from being up.
+func TestABusRefusalIsRecognisedInBothWordings(t *testing.T) {
+	for _, wording := range []string{
+		"incus exec: Failed to connect system bus: No such file or directory",
+		"Failed to connect to bus: No such file or directory",
+	} {
+		asks := 0
+		f := &fakeRuntime{answers: map[string]string{
+			"ip -o link show dev": "2: eth0: <BROADCAST,MULTICAST,UP>\n",
+			"resolvectl dns eth0": "Link 2 (eth0): " + DefaultResolver + "\n",
+		}}
+		f.hook = func(_ int, args []string) ([]byte, error, bool) {
+			if len(args) >= 5 && args[0] == "exec" && args[3] == "networkctl" && args[4] == "status" {
+				asks++
+				if asks < 3 {
+					return nil, errors.New(wording), true
+				}
+				return []byte("    Network File: /run/systemd/network/10-netplan-eth0.network\n"), nil, true
+			}
+			return nil, nil, false
+		}
+		d := newFakeDriver(f)
+		d.OVN = true
+		d.resolverPoll = time.Millisecond
+
+		d.setGuestResolver(context.Background(), "srv", "eth0")
+
+		if asks < 3 {
+			t.Errorf("%q was read as permanent: the lookup gave up after %d ask(s)", wording, asks)
 		}
 	}
 }

--- a/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
+++ b/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
@@ -126,6 +126,78 @@
       "find": "\tif _, err := netip.ParseAddr(d.resolver()); err != nil {",
       "replace": "\tif _, err := netip.ParseAddr(d.resolver()); err != nil && false {",
       "test": "TestAResolverThatIsNotAnAddressReachesNoCommand"
+    },
+    {
+      "label": "the unit lookup is asked once with no retry, which is what left a cold-attached machine with no drop-in at all (#694)",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif time.Now().After(deadline) {\n\t\t\t// Said, not swallowed.",
+      "replace": "\t\tif time.Now().After(deadline) || true {\n\t\t\t// Said, not swallowed. A drop-in that was never written is a machine",
+      "test": "TestTheUnitLookupWaitsForTheGuest"
+    },
+    {
+      "label": "a guest that never names a unit is swallowed again, so a machine with no resolver leaves no trace in the log",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\td.logger().Warn(\"the guest never named a network unit, so it has no resolver of ours\",",
+      "replace": "\t\t\td.logger().Debug(\"the guest never named a network unit, so it has no resolver of ours\",",
+      "test": "TestAUnitThatNeverAppearsIsSaid"
+    },
+    {
+      "label": "an answered ask with no unit is retried like a failure, which charges every boot the whole budget for nothing",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif err == nil {\n\t\t\treturn \"\"\n\t\t}",
+      "replace": "\t\tif err == nil && false {\n\t\t\treturn \"\"\n\t\t}",
+      "test": "TestAnInterfaceWithNoUnitGetsNoDropIn"
+    },
+    {
+      "label": "the unit lookup is asked once with no retry, which is what left a cold-attached machine with no drop-in at all",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif time.Now().After(deadline) {\n\t\t\t// Said, not swallowed. A drop-in that was never written is a machine",
+      "replace": "\t\tif time.Now().After(deadline) || true {\n\t\t\t// Said, not swallowed. A drop-in that was never written is a machine",
+      "test": "TestTheUnitLookupWaitsForTheGuest"
+    },
+    {
+      "label": "a guest that never names a unit is swallowed again, which is how this stayed invisible in the log while being obvious in the guest",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\td.logger().Warn(\"the guest never named a network unit, so it has no resolver of ours\",",
+      "replace": "\t\t\td.logger().Debug(\"the guest never named a network unit, so it has no resolver of ours\",",
+      "test": "TestAUnitThatNeverAppearsIsSaid"
+    },
+    {
+      "label": "an interface that has not appeared yet is read as an image with no networkctl, so the lookup gives up on a guest about to be ready",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif !isNotRunning(err) && !guestBusNotReady(err) && !guestLinkNotThereYet(err, iface) &&\n\t\t\tguestHasNoNetworkd(err) {",
+      "replace": "\t\tif !isNotRunning(err) && !guestBusNotReady(err) && guestLinkNotThereYet(err, iface) &&\n\t\t\tguestHasNoNetworkd(err) {",
+      "test": "TestALinkThatIsNotThereYetIsWaitedFor"
+    },
+    {
+      "label": "an answer that named no unit is retried, so every fixture that answers nothing pays the whole budget",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif err == nil {\n\t\t\treturn \"\"\n\t\t}",
+      "replace": "\t\tif err == nil && false {\n\t\t\treturn \"\"\n\t\t}",
+      "test": "TestAnInterfaceWithNoUnitGetsNoDropIn"
+    },
+    {
+      "label": "a machine that is still starting is read as an image with no networkctl, which is what burned the whole budget against a container that had not booted",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif !isNotRunning(err) && !guestBusNotReady(err) && !guestLinkNotThereYet(err, iface) &&\n\t\t\tguestHasNoNetworkd(err) {",
+      "replace": "\t\tif isNotRunning(err) {\n\t\t\treturn \"\"\n\t\t}\n\t\tif !isNotRunning(err) && !guestBusNotReady(err) && !guestLinkNotThereYet(err, iface) &&\n\t\t\tguestHasNoNetworkd(err) {",
+      "test": "TestAMachineStillStartingIsWaitedFor"
+    },
+    {
+      "label": "the bus refusal is matched by one wording only, so the wording the guest actually sends falls through to the permanent matcher and the lookup gives up on its first ask",
+      "file": "internal/core/machine/incus_resolver.go",
+      "package": "./internal/core/machine/",
+      "find": "\treturn strings.Contains(msg, \"failed to connect\") && strings.Contains(msg, \"bus\")",
+      "replace": "\treturn strings.Contains(msg, \"failed to connect\") && strings.Contains(msg, \"bus\") && strings.Contains(msg, \"to bus\")",
+      "test": "TestABusRefusalIsRecognisedInBothWordings"
     }
   ]
 }


### PR DESCRIPTION
The ordinary Terraform order — create the server, attach the private NIC, power
on — came up with the uplink's own address as its only name server and no
drop-in at all. That address is what Incus falls back to announcing when nobody
else does, and it is #660's dead on-link route arriving through somebody else's
default rather than ours.

FOUR HYPOTHESES, THREE OF THEM WRONG, AND HOW THE LAST WAS FOUND.

The first was that `guestNetworkUnit` asked a guest whose systemd was not up:
plausible, and refuted — a retry changed nothing. The second was that
`Interface "eth0" not found.` was being read as `networkctl: not found`, which
IS a real confusion of the same family this file has already paid for twice, and
fixing it changed nothing either.

The third was that the budget was too short: the driver's log beside the guest's
answers, polled every two seconds from the poweron, said

    t+2 .. t+40   Error: Instance is not running
    t+42          links=[lo eth0@if182]
    t+44          eth0 -> /run/systemd/network/10-netplan-eth0.network
    driver        gave up after 30s, twelve seconds before the guest was ready

so `Instance is not running` was in none of the transient cases and burned the
whole budget against a machine that had not started. Raising it to 90s changed
nothing either, and THAT is what finally forced the right method: printing the
error the guest sends instead of reasoning about it.

    incus exec: Failed to connect system bus: No such file or directory

The matcher looked for `failed to connect to bus` — with a "to" the message does
not carry. So the refusal fell through to the permanent matcher, which accepts
"no such file or directory", and the lookup gave up on its FIRST ask against a
guest whose systemd was seconds from being up. Third time in this file, same
family, and the only one of the four hypotheses that was not a guess.

WHAT CHANGES.

A machine that is not running is the most transient answer of all, and it is now
the first one asked about. The budget clears the measured boot with margin: 10s
was the first value, 30s the second, and both gave up before the container had
started. It costs nothing when the guest is quick — the wait ends the moment it
answers — and what it now covers is a boot the client is already waiting on.

The two corrections the wrong hypotheses produced are kept, because both are
real and both were measured on their own terms: an interface that has not
appeared yet is told from a binary that never will be, and an answer that named
no unit is no longer retried like a failure — written the other way, every
fixture answering nothing paid the whole budget and this package's unit suite
went from seconds to ten minutes.

MEASURED, ON THE SHAPE THE ISSUE NAMES.

A private machine behind a Public Gateway pushing the default route, NIC
attached while stopped, under `--vm incus-ovn`, 2026-09-06:

    moment                       resolvectl dns   drop-in   dns   tcp443
    first boot, NIC cold         1.1.1.1          present   ok    ok
    after a reboot               1.1.1.1          present   ok    ok

Both rows read `10.209.83.1`, no drop-in, `dns: no` before this — the uplink's
own address, which is what Incus falls back to announcing when nobody else does.

Seventeen mutations bite across the spec, six of them new — including one that
had to be rewritten because flipping its term changed no behaviour at all: the
rest of that condition stayed false, the loop kept retrying, and the test kept
passing. A mutation that changes a term without changing what runs is the guard
measuring itself.

Closes #694


🤖 Generated with [Claude Code](https://claude.com/claude-code)
