### PR TITLE
fix(exoscale): an elastic IP reads its labels back (#703)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -330,6 +330,24 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une elastic IP Exoscale relit ses labels** (#703).
+  `exoscale/v2.create-elastic-ip` et `exoscale/v2.update-elastic-ip`
+  déclaraient `labels` dans leur structure de requête et ne stockaient rien,
+  et aucune vue ne servait le champ : `exoscale/v2.get-elastic-ip` et
+  `exoscale/v2.list-elastic-ips` répondaient une adresse étiquetée sans
+  labels alors que sa description, venue du même corps, revenait bien, et le
+  second plan d'une stack qui étiquette son adresse n'était jamais vide.
+  Mesuré le 2026-09-05 avec le SDK Python, et sous le provider 0.71.0 comme
+  `Plan: 0 to add, 1 to change` sur la seule ressource des vingt-trois qui
+  porte des labels. Stockés à la création,
+  remplacés à la mise à jour quand le client envoie le champ et intacts quand
+  il ne l'envoie pas, vidés par une map vide, servis quand ils existent et
+  absents sinon, comme le private network le faisait déjà. La même passe a
+  ramené `exoscale/v2.reset-elastic-ip-field` à ce que la description d'API
+  déclare,
+  `description` seul : le pack y acceptait `labels` et `healthcheck`, absents
+  de l'énumération du contrat, et le premier répondait 200 en vidant un champ
+  jamais stocké.
 - **`feint env exoscale` dit à un utilisateur de Terraform ce que l'émulateur
   fait aujourd'hui** (#701). La note sur stderr disait encore, un jour après
   que #644 a levé le refus, que le provider honore `EXOSCALE_API_ENDPOINT`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,22 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **An Exoscale elastic IP reads its labels back** (#703).
+  `exoscale/v2.create-elastic-ip` and `exoscale/v2.update-elastic-ip` declared
+  `labels` in their request structs and stored nothing, and no view served the
+  field, so `exoscale/v2.get-elastic-ip` and `exoscale/v2.list-elastic-ips`
+  answered a labelled address without labels while its description, from the
+  same body, came back fine, and the second plan of a stack that labels its
+  address was never empty: measured on 2026-09-05 with the Python SDK, and
+  under provider 0.71.0 as `Plan: 0 to add, 1 to change` on the one resource
+  of twenty-three carrying labels.
+  Stored on create, replaced on update when the client sends the field and
+  left alone when it does not, cleared by an empty map, served when non-empty
+  and absent otherwise, the way the private network already did. The same
+  pass narrowed `exoscale/v2.reset-elastic-ip-field` to what the API description declares,
+  `description` alone: the pack accepted `labels` and `healthcheck` there,
+  neither in the contract's enum, and the first answered 200 while clearing a
+  field it had never stored.
 - **`feint env exoscale` tells a Terraform user what the emulator does today**
   (#701). The note on stderr still said, a day after #644 had lifted the
   refusal, that the provider honours `EXOSCALE_API_ENDPOINT` for half of itself

--- a/internal/providers/exoscale/account.go
+++ b/internal/providers/exoscale/account.go
@@ -115,10 +115,14 @@ var resettableInstanceFields = map[string]string{
 	"tpm-enabled": "tpm-enabled",
 }
 
+// resettableElasticIPFields is the enum their API description declares for
+// reset-elastic-ip-field, and it is one entry long: description. It used to
+// list healthcheck and labels too, neither of which the contract names, and
+// labels was not even stored, so that reset answered 200 and cleared nothing
+// (#703). A list wider than the enum answers 200 where the API refuses.
+// TestOnlyTheDescriptionOfAnElasticIPIsResettable fails when it grows.
 var resettableElasticIPFields = map[string]string{
 	"description": "description",
-	"healthcheck": "healthcheck",
-	"labels":      "labels",
 }
 
 func (p *Pack) resetInstanceField(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/exoscale/elasticips.go
+++ b/internal/providers/exoscale/elasticips.go
@@ -12,7 +12,8 @@ import (
 )
 
 // Elastic IPs, in the measured shape: {addressfamily, cidr, description, id,
-// ip}, description omitted when empty. Attach and detach are actions on the IP
+// ip}, description omitted when empty, and labels when the client set some:
+// the schema declares them, and a labelled stack reads them back (#703). Attach and detach are actions on the IP
 // naming the instance, and the operation they mint refers to the elastic IP,
 // not the instance — that is what the recording shows the provider waiting on.
 //
@@ -151,6 +152,14 @@ func (p *Pack) createElasticIP(w http.ResponseWriter, r *http.Request) {
 	if req.Healthcheck != nil {
 		res.Attrs["healthcheck"] = req.Healthcheck
 	}
+	// Stored on create and served by elasticIPView, the way the private network
+	// does (#703): the request struct declared the field for as long as the pack
+	// existed and nothing read it, so a labelled stack's second plan was never
+	// empty. Absent rather than empty when none, the omission habit measured on
+	// this API. TestAnElasticIPReadsItsLabelsBack fails without this.
+	if len(req.Labels) > 0 {
+		res.Attrs["labels"] = labelsToAttr(req.Labels)
+	}
 	p.env.Store.Put(res)
 	p.writeOperation(w, p.operationReferring(nounElasticIP, res.ID))
 }
@@ -238,6 +247,14 @@ func (p *Pack) updateElasticIP(w http.ResponseWriter, r *http.Request) {
 		if req.Healthcheck != nil {
 			stored.Attrs["healthcheck"] = req.Healthcheck
 		}
+		// Nil is a field the client did not send, and it stays; an empty map is
+		// the client clearing the labels, which is how the CLI clears any field
+		// on this API (measured: an update with an empty value, never the
+		// per-field DELETE). TestAnElasticIPUpdateReplacesItsLabelsAndSilenceKeepsThem
+		// fails on either half without this.
+		if req.Labels != nil {
+			stored.Attrs["labels"] = labelsToAttr(req.Labels)
+		}
 		stored.Updated = p.env.Now()
 		return nil
 	})
@@ -321,6 +338,9 @@ func elasticIPView(res *resource.Resource) map[string]any {
 	}
 	if healthcheck, ok := res.Attrs["healthcheck"].(map[string]any); ok {
 		out["healthcheck"] = healthcheck
+	}
+	if labels, _ := res.Attrs["labels"].(map[string]any); len(labels) > 0 {
+		out["labels"] = labels
 	}
 	return out
 }

--- a/internal/providers/exoscale/elasticips_test.go
+++ b/internal/providers/exoscale/elasticips_test.go
@@ -1,0 +1,147 @@
+package exoscale_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// Elastic IP labels (#703). The `elastic-ip` schema this pack is generated
+// against declares `labels`, create-elastic-ip and update-elastic-ip take them,
+// and the request structs here declared the field from the start — and
+// nothing stored it, so a labelled address read back without labels while its
+// description, from the same body, read back fine. Measured on 2026-09-05 with
+// the Python SDK against main at 9074c0f, and under Terraform as the one
+// resource of twenty-three whose second plan was never empty:
+//
+//	~ resource "exoscale_elastic_ip" "bastion" {
+//	    ~ labels = { + "example" = "temoin0.71.0" }
+//	Plan: 0 to add, 1 to change, 0 to destroy.
+//
+// Every assertion here is on what a client reads after writing, which is the
+// only place the defect was visible.
+
+// createTestElasticIP posts an elastic IP and returns the id the operation
+// refers to, the way the SDK follows a create.
+func createTestElasticIP(t *testing.T, h http.Handler, body string) string {
+	t.Helper()
+	rec, op := call(t, h, "POST", "/v2/elastic-ip", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("elastic IP create answered %d: %v", rec.Code, op)
+	}
+	ref, _ := op["reference"].(map[string]any)
+	id, _ := ref["id"].(string)
+	if id == "" {
+		t.Fatalf("the create's operation refers to nothing: %v", op)
+	}
+	return id
+}
+
+// The labels a create carries come back on the get and on the list, and an
+// address created without any carries no `labels` key at all — absent rather
+// than empty, the omission habit measured on this API and held on the private
+// network next door.
+func TestAnElasticIPReadsItsLabelsBack(t *testing.T) {
+	h := serve(t)
+	want := map[string]any{"example": "mesure-labels", "role": "temoin"}
+	labelled := createTestElasticIP(t, h,
+		`{"description":"mesure-labels","labels":{"example":"mesure-labels","role":"temoin"}}`)
+	bare := createTestElasticIP(t, h, `{"description":"no labels"}`)
+
+	rec, got := call(t, h, "GET", "/v2/elastic-ip/"+labelled, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get answered %d: %v", rec.Code, got)
+	}
+	if got["description"] != "mesure-labels" {
+		t.Errorf("the description from the same body did not survive: %v", got)
+	}
+	if !reflect.DeepEqual(got["labels"], want) {
+		t.Errorf("get: labels are %v, want %v", got["labels"], want)
+	}
+
+	_, listed := call(t, h, "GET", "/v2/elastic-ip", "")
+	seen := 0
+	for _, entry := range listed["elastic-ips"].([]any) {
+		eip, _ := entry.(map[string]any)
+		switch eip["id"] {
+		case labelled:
+			seen++
+			if !reflect.DeepEqual(eip["labels"], want) {
+				t.Errorf("list: labels are %v, want %v", eip["labels"], want)
+			}
+		case bare:
+			seen++
+			if _, present := eip["labels"]; present {
+				t.Errorf("list: an address created without labels carries %v", eip["labels"])
+			}
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("the list holds %d of the 2 addresses created", seen)
+	}
+	_, plain := call(t, h, "GET", "/v2/elastic-ip/"+bare, "")
+	if _, present := plain["labels"]; present {
+		t.Errorf("get: an address created without labels carries %v", plain["labels"])
+	}
+}
+
+// An update that names labels replaces them; one that does not leaves them
+// alone; an empty map clears them, which is how the CLI clears any field on this
+// API (an update with an empty value, never the per-field DELETE). Nil and empty
+// are two different requests, the distinction #404 asks of every update.
+func TestAnElasticIPUpdateReplacesItsLabelsAndSilenceKeepsThem(t *testing.T) {
+	h := serve(t)
+	id := createTestElasticIP(t, h, `{"labels":{"role":"temoin"}}`)
+	read := func() map[string]any {
+		t.Helper()
+		_, got := call(t, h, "GET", "/v2/elastic-ip/"+id, "")
+		return got
+	}
+
+	if rec, out := call(t, h, "PUT", "/v2/elastic-ip/"+id, `{"description":"renamed"}`); rec.Code != http.StatusOK {
+		t.Fatalf("an update without labels answered %d: %v", rec.Code, out)
+	}
+	if got := read(); !reflect.DeepEqual(got["labels"], map[string]any{"role": "temoin"}) || got["description"] != "renamed" {
+		t.Errorf("an update that did not name labels changed them: %v", got)
+	}
+
+	if rec, out := call(t, h, "PUT", "/v2/elastic-ip/"+id, `{"labels":{"role":"web","tier":"edge"}}`); rec.Code != http.StatusOK {
+		t.Fatalf("a labels update answered %d: %v", rec.Code, out)
+	}
+	if got := read(); !reflect.DeepEqual(got["labels"], map[string]any{"role": "web", "tier": "edge"}) {
+		t.Errorf("an update naming labels did not replace them: %v", got["labels"])
+	}
+
+	if rec, out := call(t, h, "PUT", "/v2/elastic-ip/"+id, `{"labels":{}}`); rec.Code != http.StatusOK {
+		t.Fatalf("clearing the labels answered %d: %v", rec.Code, out)
+	}
+	if got := read(); got["labels"] != nil {
+		t.Errorf("an empty map did not clear the labels: %v", got["labels"])
+	}
+}
+
+// reset-elastic-ip-field's enum is one entry long in the API description:
+// description. The pack used to accept labels and healthcheck there too, and
+// answered 200 while clearing a labels field it had never stored.
+func TestOnlyTheDescriptionOfAnElasticIPIsResettable(t *testing.T) {
+	h := serve(t)
+	id := createTestElasticIP(t, h, `{"description":"to reset","labels":{"role":"temoin"}}`)
+
+	for _, field := range []string{"labels", "healthcheck", "ip"} {
+		if rec, out := call(t, h, "DELETE", "/v2/elastic-ip/"+id+"/"+field, ""); rec.Code != http.StatusBadRequest {
+			t.Errorf("resetting %s, which the contract does not declare resettable, answered %d: %v",
+				field, rec.Code, out)
+		}
+	}
+	// The declared one works, or the guard refuses everything and proves nothing.
+	if rec, out := call(t, h, "DELETE", "/v2/elastic-ip/"+id+"/description", ""); rec.Code != http.StatusOK {
+		t.Fatalf("resetting the description answered %d: %v", rec.Code, out)
+	}
+	_, got := call(t, h, "GET", "/v2/elastic-ip/"+id, "")
+	if _, present := got["description"]; present {
+		t.Errorf("the description survived its reset: %v", got)
+	}
+	if !reflect.DeepEqual(got["labels"], map[string]any{"role": "temoin"}) {
+		t.Errorf("resetting the description touched the labels: %v", got["labels"])
+	}
+}

--- a/tools/falsify/specs/an-elastic-ip-reads-its-labels-back.json
+++ b/tools/falsify/specs/an-elastic-ip-reads-its-labels-back.json
@@ -1,0 +1,40 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the create stops storing the labels, so a labelled address reads back without them, which is #703 verbatim",
+      "file": "internal/providers/exoscale/elasticips.go",
+      "find": "\tif len(req.Labels) > 0 {\n\t\tres.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t}\n\tp.env.Store.Put(res)",
+      "replace": "\tif len(req.Labels) > 0 && false {\n\t\tres.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t}\n\tp.env.Store.Put(res)",
+      "test": "TestAnElasticIPReadsItsLabelsBack"
+    },
+    {
+      "label": "the view stops serving the labels it holds, so get and list answer without them while the store has them",
+      "file": "internal/providers/exoscale/elasticips.go",
+      "find": "\tif labels, _ := res.Attrs[\"labels\"].(map[string]any); len(labels) > 0 {\n\t\tout[\"labels\"] = labels\n\t}",
+      "replace": "\tif labels, _ := res.Attrs[\"labels\"].(map[string]any); len(labels) > 0 && false {\n\t\tout[\"labels\"] = labels\n\t}",
+      "test": "TestAnElasticIPReadsItsLabelsBack"
+    },
+    {
+      "label": "the update stops applying the labels it is sent, so a second apply that changes them converges on nothing",
+      "file": "internal/providers/exoscale/elasticips.go",
+      "find": "\t\tif req.Labels != nil {\n\t\t\tstored.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t\t}",
+      "replace": "\t\tif req.Labels != nil && false {\n\t\t\tstored.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t\t}",
+      "test": "TestAnElasticIPUpdateReplacesItsLabelsAndSilenceKeepsThem"
+    },
+    {
+      "label": "an update that does not name labels clears them, which is the absent-versus-empty confusion of #404 on this resource",
+      "file": "internal/providers/exoscale/elasticips.go",
+      "find": "\t\tif req.Labels != nil {\n\t\t\tstored.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t\t}",
+      "replace": "\t\tif req.Labels != nil || true {\n\t\t\tstored.Attrs[\"labels\"] = labelsToAttr(req.Labels)\n\t\t}",
+      "test": "TestAnElasticIPUpdateReplacesItsLabelsAndSilenceKeepsThem"
+    },
+    {
+      "label": "the reset list grows labels back, a field the API description does not declare resettable on an elastic IP",
+      "file": "internal/providers/exoscale/account.go",
+      "find": "var resettableElasticIPFields = map[string]string{\n\t\"description\": \"description\",\n}",
+      "replace": "var resettableElasticIPFields = map[string]string{\n\t\"description\": \"description\",\n\t\"labels\":      \"labels\",\n}",
+      "test": "TestOnlyTheDescriptionOfAnElasticIPIsResettable"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`create-elastic-ip` and `update-elastic-ip` declared `labels` in their request
structs from the day the resource was written, and nothing stored the field; no
view served it. A labelled address read back without labels while its
description, from the same body, read back fine, which is what #703 measured
with the Python SDK, and under provider 0.71.0 as the one resource of
twenty-three whose second plan was never empty.

MEASURED HERE BEFORE THE FIX, with the tests this pull request adds, on `main`
at cd667b8:

```text
get:  labels are <nil>, want map[example:mesure-labels role:temoin]
list: labels are <nil>, want map[example:mesure-labels role:temoin]
DELETE /elastic-ip/{id}/labels       200   (the contract's enum: description)
DELETE /elastic-ip/{id}/healthcheck  200   (same)
```

The premise holds. The second pair is what the measurement added.

WHAT CHANGES, AND WHAT IT COPIES.

Stored on create when non-empty, replaced on update when the client sends the
field and left alone when it does not, cleared by an empty map, served when
non-empty and absent otherwise. None of that is new to this pack: it is what
`privatenetworks.go` does for the same field, and what the CLI was measured
doing to clear a field on this API (an update with an empty value, never the
per-field DELETE). Nil and empty are two different requests on the update,
the distinction #404 asks of every update in the lot.

THE RESET LIST IS THE CONTRACT'S ENUM, AND THE ONE THING HERE TO OBJECT TO.

`resettableElasticIPFields` listed `description`, `healthcheck` and `labels`.
The upstream description of `reset-elastic-ip-field`
(`.upstream/exoscale-openapi.yaml`) declares one value, `description`; the
instance's and the private network's declare `labels` alone, and the private
network's handler already says so. The elastic IP's list answered 200 on two
fields the API refuses, and on one it had never stored, so the reset cleared
nothing and said it had. The list is the enum now.
`resettableInstanceFields` is wider than its enum too (`labels`, `user-data`,
`name`, `tpm-enabled` against `labels`) and is left alone: a different
resource, unmeasured against a client, not this issue. Worth its own look.

Five mutations bite in `an-elastic-ip-reads-its-labels-back.json`: the create
stops storing, the view stops serving, the update stops applying, the update
clears on silence, the reset list grows labels back.

WHAT WAS NOT PLAYED, WRITTEN DOWN.

`mise run testplan` earned `conformance:leg -- exo-cli` and
`conformance:leg -- fields` for this pack, plus the spec above and the ones
that mutate `elasticips.go` and `account.go`. The specs ran and bite;
`prepush` is green. **No conformance leg was played**: the station is held by a
runtime measurement under `incus-ovn`, and the owner plays the pass once on the
assembled lot. What the `fields` leg would prove here: that `exo` and the
Exoscale Terraform suite still pass with a view that now carries one more key
when set, and that the omission gate does not name `labels` as unread on the
elastic IP routes. `examples/stacks/exoscale` declares no labels on its elastic
IP, so `terraform.sh` cannot see the fix either way; the collection stack in
#703 can.

## Type of change

- [x] A route added or changed (response shape: `labels` served on
      `get-elastic-ip` / `list-elastic-ips`; `reset-elastic-ip-field` refuses
      two fields it accepted)
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, through `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: untouched
- [x] Nothing in the diff could be written identically for another provider:
      the field name, the omission habit and the reset enum are this API's
- [x] `mise run testplan` was run, and what it printed was run except the
      conformance legs, named above with why and what they would prove

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **not run**, deliberately, see
      above; written here rather than ticked
- [x] Every field name in the diff comes from the provider's OpenAPI document:
      `labels` is `components.schemas.elastic-ip.properties.labels` and the
      create/update request bodies of `/elastic-ip`; the reset enum is
      `reset-elastic-ip-field`'s `field` parameter

### When a route is added or changed — otherwise N/A

- [x] The routes keep their upstream operations; none is added
- [ ] `mise run conformance` passes — **not run**, see above. The unit tests
      hold the shape against the schema; the `fields` leg is owed
- [x] The response was validated against the provider's own API description:
      the pre-commit hook "routes match the provider's API description" is
      green, and `labels` is served as the schema's `object` of strings
- [x] What the client sends is read: `labels` was the one declared field of
      `createElasticIPRequest` and `updateElasticIPRequest` nothing read, and
      the omission report (`unread_request_fields`) would have named it the
      first time a client sent it
- [x] `mise run drift:update`: N/A, no operation changed hands; `drift:check`
      green through `prepush`

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md`: no limit moved; the field was declared and unserved,
      which no limit recorded
- [x] The README's generated tables: `feint docs --check` green through
      `prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: no runtime, no `FEINT_VM`, no container started.

## Related issues

Closes #703
