### PR TITLE
fix(outscale): ReadImages and ReadSnapshots serve Filters.AccountAliases (#700)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -330,6 +330,22 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **`osc/Client.ReadImages` et `osc/Client.ReadSnapshots` servent
+  `Filters.AccountAliases`** (#700), le filtre que l'exemple `ReadImages` du
+  contrat utilise lui-même. Les deux lectures le refusaient avec le 4001 qui
+  nomme ce qu'elles servent, mesuré le 2026-09-05 avec osc-sdk-python 0.42.0
+  et reproduit le 2026-09-06 avant le correctif. Il sélectionne sur l'alias du propriétaire, et cet
+  alias est désormais sur chaque objet que le propriétaire détient : les
+  images du catalogue portaient `AccountAlias` depuis #95 et une image
+  enregistrée ou un snapshot du même `AccountId` n'en portaient pas, si bien
+  que le filtre aurait coupé un seul propriétaire en deux. Le schéma
+  `Snapshot` déclare le champ à côté d'`AccountId`, et le vrai cloud le met
+  sur une image dont le propriétaire a un alias (`shapes/outscale.json`). Ce
+  qui reste, et que `docs/limits.md` consigne : le catalogue appartient au
+  compte émulé, par décision, donc `AccountAliases: [Outscale]` répond une
+  liste vide ici plutôt qu'un catalogue réétiqueté avec un identifiant de
+  compte que le corpus masque, et `self` n'est pas un alias que cette API a
+  été mesurée accepter.
 - **Une elastic IP Exoscale relit ses labels** (#703).
   `exoscale/v2.create-elastic-ip` et `exoscale/v2.update-elastic-ip`
   déclaraient `labels` dans leur structure de requête et ne stockaient rien,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,20 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **`osc/Client.ReadImages` and `osc/Client.ReadSnapshots` serve
+  `Filters.AccountAliases`** (#700), the filter the contract's own `ReadImages`
+  example uses. Both reads refused it with the 4001 that names what they
+  serve, measured on 2026-09-05 through osc-sdk-python 0.42.0 and reproduced
+  on 2026-09-06 before the fix. It selects on the owner's alias, and the owner's alias is
+  now on every object the owner holds: the catalogue's images carried
+  `AccountAlias` since #95 and a registered image or a snapshot of the same
+  `AccountId` carried none, so the filter would have split one owner in two.
+  The `Snapshot` schema declares the field beside `AccountId`, and the real
+  cloud puts it on an image whose owner has an alias (`shapes/outscale.json`).
+  What stays, and `docs/limits.md` records: the catalogue is the emulated
+  account's, by decision, so `AccountAliases: [Outscale]` answers an empty
+  list here rather than a catalogue relabelled with an owner id the corpus
+  redacts, and `self` is not an alias this API was measured accepting.
 - **An Exoscale elastic IP reads its labels back** (#703).
   `exoscale/v2.create-elastic-ip` and `exoscale/v2.update-elastic-ip` declared
   `labels` in their request structs and stored nothing, and no view served the

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -571,6 +571,29 @@ the table is its fix); an emulator-side refusal would add a second wall for
 raw SDK users and catch nothing the first does not. The real cloud does
 refuse an unknown type, so this is a divergence, recorded here on purpose.
 
+### The Outscale catalogue belongs to the emulated account, so `AccountAliases: [Outscale]` selects nothing (#700)
+
+`ReadImages` and `ReadSnapshots` serve `Filters.AccountAliases` since #700, on
+the owner's alias every image and snapshot carries. There is one owner in
+this emulator, and the fixed catalogue is its by decision (`catalog.go`:
+`PermissionsToLaunch` names the emulated account as the owner of every
+catalogue image), so the alias the catalogue publishes is the account's own.
+Two consequences a client should expect:
+
+- the contract's own `ReadImages` example, `AccountAliases: [Outscale]` with
+  `ImageNames: [Ubuntu*, RockyLinux*]`, answers an empty list here: nothing
+  this emulator serves is Outscale's, and it says so rather than relabel a
+  catalogue whose `AccountId` is the account's;
+- selecting the account's own images apart from the catalogue by owner is
+  not possible here, since both halves have the same owner. A residue check
+  that wants the client's half alone lists without the filter and compares
+  against the catalogue, which is fixed.
+
+Giving the catalogue Outscale's identity would need Outscale's account id,
+which the recorded corpus redacts along with every other `AccountId`; it is
+not invented. That `self` is accepted as an alias by the real API was not
+measured either, and it is not accepted here.
+
 ## `lb/v1` refusals carry an envelope the real one does not
 
 Measured on `fr-par`, 2026-09-02 (#394). Three refusals of the load balancer

--- a/internal/providers/outscale/accountalias_test.go
+++ b/internal/providers/outscale/accountalias_test.go
@@ -1,0 +1,127 @@
+package outscale_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// AccountAliases (#700). FiltersImage and FiltersSnapshot declare it, the
+// contract's own ReadImages example uses it (`AccountAliases: [Outscale]` with
+// `ImageNames: [Ubuntu*, RockyLinux*]`), and both reads refused it here with
+// the honest 4001 that names what they serve. Measured through osc-sdk-python
+// on v0.12.1, and reproduced by the first test below before the fix.
+//
+// What the alias is, in this emulator. The catalogue's images already carried
+// AccountAlias (#95: one of the nine fields the real cloud puts on every image,
+// shapes/outscale.json), and a registered image or a snapshot carried none
+// while sharing the catalogue's AccountId — the same owner, published two
+// ways. One owner, one alias: every image and snapshot the emulator answers
+// carries the catalogue's, and the filter that selects by owner selects
+// consistently. The catalogue belongs to the emulated account by decision
+// (catalog.go, PermissionsToLaunch names it as the owner), so
+// `AccountAliases: [Outscale]` selects nothing here; docs/limits.md says so.
+//
+// Neither test names the alias: it is read off the catalogue, so the tests
+// hold consistency rather than a value.
+
+// catalogueAlias is the alias the catalogue's first image publishes, which is
+// what every other object of the same owner is held to.
+func catalogueAlias(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	_, out := post(t, ts, "ReadImages", `{}`)
+	images, _ := out["Images"].([]any)
+	if len(images) == 0 {
+		t.Fatal("the image catalogue is empty, so nothing here has an owner to read")
+	}
+	first, _ := images[0].(map[string]any)
+	alias, _ := first["AccountAlias"].(string)
+	if alias == "" {
+		t.Fatalf("the catalogue's first image carries no AccountAlias: %v", first)
+	}
+	return alias
+}
+
+// ownedInventory is inventory plus an image the client registered, so both
+// reads answer a catalogue half and a client half.
+func ownedInventory(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	inventory(t, ts)
+	_, vms := post(t, ts, "ReadVms", `{}`)
+	list, _ := vms["Vms"].([]any)
+	if len(list) == 0 {
+		t.Fatal("inventory created no Vm to register an image from")
+	}
+	vm, _ := list[0].(map[string]any)
+	vmID, _ := vm["VmId"].(string)
+	if status, out := post(t, ts, "CreateImage", `{"ImageName":"own-image","VmId":"`+vmID+`"}`); status != http.StatusOK {
+		t.Fatalf("CreateImage answered %d: %v", status, out)
+	}
+}
+
+// count is how many objects a read answers under a key, after the response
+// has been held to the contract.
+func count(t *testing.T, ts *httptest.Server, action, body, key string) int {
+	t.Helper()
+	out := call(t, ts, contractDoc(t), action, body)
+	list, _ := out[key].([]any)
+	return len(list)
+}
+
+func TestReadImagesAndReadSnapshotsFilterByAccountAlias(t *testing.T) {
+	ts := newServer(t)
+	ownedInventory(t, ts)
+	alias := catalogueAlias(t, ts)
+
+	for _, read := range []struct{ action, key string }{
+		{"ReadImages", "Images"}, {"ReadSnapshots", "Snapshots"},
+	} {
+		all := count(t, ts, read.action, `{}`, read.key)
+		if all < 2 {
+			t.Fatalf("%s answers %d objects unfiltered; the sweep below would prove nothing", read.action, all)
+		}
+		// The owner's alias selects everything the owner holds, catalogue and
+		// client halves alike.
+		if got := count(t, ts, read.action, `{"Filters":{"AccountAliases":["`+alias+`"]}}`, read.key); got != all {
+			t.Errorf("%s AccountAliases [%s] answers %d of the %d objects that owner holds", read.action, alias, got, all)
+		}
+		// And an alias nobody here carries selects nothing: the contract's own
+		// example asks for Outscale's images, and this catalogue is not theirs.
+		if got := count(t, ts, read.action, `{"Filters":{"AccountAliases":["Outscale"]}}`, read.key); got != 0 {
+			t.Errorf("%s AccountAliases [Outscale] answers %d objects, and nothing here is Outscale's", read.action, got)
+		}
+	}
+}
+
+// Every image and every snapshot carries the one owner's alias next to its
+// AccountId, whether the catalogue or a client made it. Before #700 the
+// catalogue's images carried it and nothing else did.
+func TestEveryImageAndSnapshotCarriesItsOwnerAlias(t *testing.T) {
+	ts := newServer(t)
+	ownedInventory(t, ts)
+	alias := catalogueAlias(t, ts)
+
+	for _, read := range []struct{ action, key, id string }{
+		{"ReadImages", "Images", "ImageId"}, {"ReadSnapshots", "Snapshots", "SnapshotId"},
+	} {
+		_, out := post(t, ts, "ReadImages", `{}`)
+		if read.action == "ReadSnapshots" {
+			_, out = post(t, ts, "ReadSnapshots", `{}`)
+		}
+		list, _ := out[read.key].([]any)
+		if len(list) < 2 {
+			t.Fatalf("%s answers %d objects; a catalogue and a client half were expected", read.action, len(list))
+		}
+		accounts := map[string]bool{}
+		for _, entry := range list {
+			object, _ := entry.(map[string]any)
+			accounts[object["AccountId"].(string)] = true
+			if got, _ := object["AccountAlias"].(string); got != alias {
+				t.Errorf("%s: %s carries AccountAlias %q, and its owner's alias is %q", read.action, object[read.id], got, alias)
+			}
+		}
+		if len(accounts) != 1 {
+			t.Errorf("%s answers objects of %d accounts; this emulator has one", read.action, len(accounts))
+		}
+	}
+}

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -203,7 +203,7 @@ func imageStructure(name string, snapshot map[string]any) map[string]any {
 		// so a client filtering images by tag had nothing to filter on.
 		// BootModes and TpmMandatory decide whether a client offers UEFI or
 		// secure boot at all.
-		"AccountAlias":   "feint",
+		"AccountAlias":   accountAlias,
 		"BootModes":      []any{"legacy", "uefi"},
 		"CreationDate":   catalogueDate,
 		"Description":    name,
@@ -281,6 +281,7 @@ func snapshotStructure(entry map[string]any) map[string]any {
 		"State":        "completed",
 		"Progress":     100,
 		"AccountId":    accountID,
+		"AccountAlias": accountAlias,
 		"CreationDate": catalogueDate,
 		"PermissionsToCreateVolume": map[string]any{
 			"AccountIds":       []any{},
@@ -368,6 +369,20 @@ var runtimeImages = map[string]machine.Image{
 // twelve digits, like AWS's.
 const accountID = "000000000001"
 
+// accountAlias is that account's alias: the value the catalogue has published
+// on its images since #95, and that every image and snapshot the emulator
+// answers carries since #700. One owner, one alias, so a client selecting by
+// AccountAliases selects consistently — before, the catalogue's images carried
+// it and a registered image or a snapshot of the same AccountId carried none.
+// The real cloud puts an alias on an image whose owner has one
+// (shapes/outscale.json, Images[].AccountAlias) and none where the account
+// has none; this account has one, and it is this.
+//
+// The catalogue is this account's, by the decision PermissionsToLaunch records
+// above, so `AccountAliases: ["Outscale"]` — the contract's own ReadImages
+// example — selects nothing here. docs/limits.md says so.
+const accountAlias = "feint"
+
 // readVmTypes pages like every other Read*: the catalogue is fixed, but a
 // client asking for N rows must still not be handed more. This was the one
 // list of the pack that ignored its ResultsPerPage — found the day the probe
@@ -420,7 +435,9 @@ func (p *Pack) readVmTypes(w http.ResponseWriter, r *http.Request) {
 // actually sends on the path to a create — it resolves the image it was given
 // before posting anything.
 var imageFilters = joinFilters(
-	stringFilters("ImageIds", "ImageNames", "AccountIds", "States", "Architectures", "RootDeviceTypes"),
+	// AccountAliases is the filter the contract's own ReadImages example uses
+	// (#700); it selects on the owner's alias every image carries.
+	stringFilters("ImageIds", "ImageNames", "AccountIds", "AccountAliases", "States", "Architectures", "RootDeviceTypes"),
 	// The three tag filters, accepted by the real account on every one of
 	// these reads (#618).
 	taggableFilters,
@@ -473,6 +490,7 @@ func imageMatches(image map[string]any, f filterSet) bool {
 	return matchesStrings(f, "ImageIds", stringOf(image["ImageId"])) &&
 		matchesStrings(f, "ImageNames", stringOf(image["ImageName"])) &&
 		matchesStrings(f, "AccountIds", accountID) &&
+		matchesStrings(f, "AccountAliases", stringOf(image["AccountAlias"])) &&
 		matchesStrings(f, "States", stringOf(image["State"])) &&
 		matchesStrings(f, "Architectures", stringOf(image["Architecture"])) &&
 		matchesStrings(f, "RootDeviceTypes", stringOf(image["RootDeviceType"]))

--- a/internal/providers/outscale/images.go
+++ b/internal/providers/outscale/images.go
@@ -273,6 +273,9 @@ func imageView(res *resource.Resource) map[string]any {
 	out["ImageId"] = res.ID
 	out["State"] = res.State
 	out["AccountId"] = accountID
+	// The owner's alias beside its id, the pair the catalogue publishes (#700).
+	// TestEveryImageAndSnapshotCarriesItsOwnerAlias fails without it.
+	out["AccountAlias"] = accountAlias
 	out["CreationDate"] = res.Created.Format(time.RFC3339)
 	return out
 }

--- a/internal/providers/outscale/snapshots.go
+++ b/internal/providers/outscale/snapshots.go
@@ -88,7 +88,7 @@ func (p *Pack) createSnapshot(w http.ResponseWriter, r *http.Request) {
 // snapshotFilters: the same lesson as volumes — a client filters on what it
 // knows, and a filter refused is an apply that stops.
 var snapshotFilters = joinFilters(
-	stringFilters("SnapshotIds", "VolumeIds", "States", "Descriptions", "AccountIds"),
+	stringFilters("SnapshotIds", "VolumeIds", "States", "Descriptions", "AccountIds", "AccountAliases"),
 	// FiltersSnapshot declares both of these as lists of integers, and both
 	// were declared here and compared nowhere: a client asking for
 	// Progresses [7] got four snapshots of Progress 100, with a 200 (#566).
@@ -167,6 +167,10 @@ func snapshotView(res *resource.Resource) map[string]any {
 	out["SnapshotId"] = res.ID
 	out["State"] = res.State
 	out["AccountId"] = accountID
+	// The Snapshot schema declares AccountAlias beside AccountId, and one owner
+	// has one alias (#700). TestEveryImageAndSnapshotCarriesItsOwnerAlias fails
+	// without it.
+	out["AccountAlias"] = accountAlias
 	out["CreationDate"] = res.Created.Format(time.RFC3339)
 	return out
 }
@@ -195,6 +199,7 @@ func snapshotMatches(view map[string]any, f filterSet) bool {
 		matchesStrings(f, "States", stringOf(view["State"])) &&
 		matchesStrings(f, "Descriptions", stringOf(view["Description"])) &&
 		matchesStrings(f, "AccountIds", stringOf(view["AccountId"])) &&
+		matchesStrings(f, "AccountAliases", stringOf(view["AccountAlias"])) &&
 		matchesInts(f, "Progresses", progress...) &&
 		matchesInts(f, "VolumeSizes", size...)
 }

--- a/tools/conformance/outscale/octl.sh
+++ b/tools/conformance/outscale/octl.sh
@@ -1098,13 +1098,18 @@ refuse_call 4001 ReadSecurityGroups    --Filters.InboundRuleAccountIds 000000000
 refuse_call 4001 ReadRouteTables       --Filters.LinkRouteTableLinkRouteTableIds rtbassoc-feintnone
 refuse_call 4001 ReadNics              --Filters.Descriptions none
 refuse_call 4001 ReadVolumes           --payload '{"Filters":{"CreationDates":["2026-01-01T00:00:00.000Z"]}}'
-refuse_call 4001 ReadSnapshots         --Filters.AccountAliases none
+# AccountAliases was the probe on ReadSnapshots and ReadImages until #700, when
+# the filter became served on both (the contract's own ReadImages example uses
+# it). ClientTokens and PermissionsToLaunchAccountIds are declared by
+# FiltersSnapshot and FiltersImage and still not applied, so the refusal stays
+# measured rather than assumed.
+refuse_call 4001 ReadSnapshots         --Filters.ClientTokens none
 refuse_call 4001 ReadPublicIps         --Filters.NicAccountIds 000000000001
 refuse_call 4001 ReadNatServices       --Filters.ClientTokens none
 refuse_call 4001 ReadInternetServices  --Filters.LinkStates available
 refuse_call 4001 ReadDhcpOptions       --Filters.DomainNameServers 192.0.2.53
 refuse_call 4001 ReadNetPeerings       --payload '{"Filters":{"ExpirationDates":["2026-01-01T00:00:00.000Z"]}}'
-refuse_call 4001 ReadImages            --Filters.AccountAliases none
+refuse_call 4001 ReadImages            --Filters.PermissionsToLaunchAccountIds 000000000001
 refuse_call 4001 ReadVmsState          --Filters.MaintenanceEventCodes none
 prove_end "$neg"
 ok "sixteen reads named the filter they do not apply, instead of answering the whole inventory"

--- a/tools/falsify/specs/read-images-and-snapshots-by-account-alias.json
+++ b/tools/falsify/specs/read-images-and-snapshots-by-account-alias.json
@@ -1,0 +1,47 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "ReadImages stops declaring AccountAliases, and the contract's own example is refused again with the 4001 of #700",
+      "file": "internal/providers/outscale/catalog.go",
+      "find": "\tstringFilters(\"ImageIds\", \"ImageNames\", \"AccountIds\", \"AccountAliases\", \"States\", \"Architectures\", \"RootDeviceTypes\"),",
+      "replace": "\tstringFilters(\"ImageIds\", \"ImageNames\", \"AccountIds\", \"AccountAliasez\", \"States\", \"Architectures\", \"RootDeviceTypes\"),",
+      "test": "TestReadImagesAndReadSnapshotsFilterByAccountAlias"
+    },
+    {
+      "label": "ReadImages accepts AccountAliases and compares it nowhere, so an alias nobody carries answers the whole catalogue with a 200 — #566's shape on a new filter",
+      "file": "internal/providers/outscale/catalog.go",
+      "find": "\t\tmatchesStrings(f, \"AccountAliases\", stringOf(image[\"AccountAlias\"])) &&",
+      "replace": "\t\tmatchesStrings(f, \"AccountAliasez\", stringOf(image[\"AccountAlias\"])) &&",
+      "test": "TestReadImagesAndReadSnapshotsFilterByAccountAlias"
+    },
+    {
+      "label": "ReadSnapshots stops declaring AccountAliases, and the filter is refused again",
+      "file": "internal/providers/outscale/snapshots.go",
+      "find": "\tstringFilters(\"SnapshotIds\", \"VolumeIds\", \"States\", \"Descriptions\", \"AccountIds\", \"AccountAliases\"),",
+      "replace": "\tstringFilters(\"SnapshotIds\", \"VolumeIds\", \"States\", \"Descriptions\", \"AccountIds\", \"AccountAliasez\"),",
+      "test": "TestReadImagesAndReadSnapshotsFilterByAccountAlias"
+    },
+    {
+      "label": "ReadSnapshots accepts AccountAliases and compares it nowhere, so an alias nobody carries answers every snapshot",
+      "file": "internal/providers/outscale/snapshots.go",
+      "find": "\t\tmatchesStrings(f, \"AccountAliases\", stringOf(view[\"AccountAlias\"])) &&",
+      "replace": "\t\tmatchesStrings(f, \"AccountAliasez\", stringOf(view[\"AccountAlias\"])) &&",
+      "test": "TestReadImagesAndReadSnapshotsFilterByAccountAlias"
+    },
+    {
+      "label": "a registered image loses its owner's alias, so the catalogue and the client's images answer the same owner two ways again",
+      "file": "internal/providers/outscale/images.go",
+      "find": "\tout[\"AccountAlias\"] = accountAlias",
+      "replace": "\tout[\"AccountAliaz\"] = accountAlias",
+      "test": "TestEveryImageAndSnapshotCarriesItsOwnerAlias"
+    },
+    {
+      "label": "a snapshot loses its owner's alias, the field the Snapshot schema declares beside AccountId",
+      "file": "internal/providers/outscale/snapshots.go",
+      "find": "\tout[\"AccountAlias\"] = accountAlias",
+      "replace": "\tout[\"AccountAliaz\"] = accountAlias",
+      "test": "TestEveryImageAndSnapshotCarriesItsOwnerAlias"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

Both reads refused `Filters.AccountAliases` with the 4001 that names what they
serve, measured through osc-sdk-python on v0.12.1 and **reproduced here before
the fix**, on `main` at cd667b8, by the tests this pull request adds:

```text
ReadImages {"Filters":{"AccountAliases":["feint"]}}   400 4001
  the filter(s) AccountAliases are not emulated; this call filters on
  AccountIds, Architectures, ImageIds, ImageNames, RootDeviceTypes, States,
  TagKeys, TagValues, Tags
```

The premise holds. `FiltersImage` and `FiltersSnapshot` declare the filter
(`contracts/outscale.json`, both closed schemas), and the contract's own
`ReadImages` example uses it.

WHAT THE MEASUREMENT ADDED: ONE OWNER, PUBLISHED TWO WAYS.

A filter selects on something the objects carry, and the objects disagreed.
The catalogue's images carried `AccountAlias: "feint"` (#95, one of the nine
fields the real cloud puts on every image, `shapes/outscale.json`); a
registered image and every snapshot, catalogue ones included, carried none,
with the same `AccountId`:

```text
ReadImages:    ami-f06739d4 carries AccountAlias "", and its owner's alias is "feint"
ReadSnapshots: snap-fe1a7001, snap-fe1a7002, snap-fe1a7003, snap-2d565034 same
```

Served on that state, `AccountAliases: [feint]` would have answered the
catalogue and not the account's own images: the wrong answer with a 200. So the
alias is one constant beside `accountID`, every image and snapshot view carries
it (the `Snapshot` schema declares it beside `AccountId`), and the filter
compares against the view, the way every filter of this pack does since #566.
Neither test names the alias; both read it off the catalogue and hold
consistency.

WHAT IT DOES NOT DO, AND WHY. THE ONE THING HERE TO OBJECT TO.

`AccountAliases: [Outscale]`, the contract's example, answers an empty list:
the catalogue is the emulated account's, by the decision `catalog.go` records at
`PermissionsToLaunch`, and its `AccountId` is the account's. Relabelling it as
Outscale's would need Outscale's account id, which the recorded corpus redacts
along with every other `AccountId` (389 of them), so it is not invented. That
`self` is an alias the real API accepts was not measured (the issue says so),
and it is not accepted here. `docs/limits.md` records both under the catalogue
section. If the catalogue is meant to become Outscale's, that is a second
decision with a measurement to make first (the owner id), and a different pull
request.

Six mutations bite in `read-images-and-snapshots-by-account-alias.json`: each
read stops declaring the filter, each read declares it and compares it nowhere
(#566's shape on a new filter), each view drops the alias.
`TestEveryDeclaredFilterCanExcludeSomething` covers the new filter from the
pack's own declarations, without anybody listing it there.

WHAT WAS NOT PLAYED, WRITTEN DOWN.

`mise run testplan` earned `falsify:lint`, `limits:check`, `docs:check`, seven
falsify specs, `conformance:leg -- octl`, `conformance:leg -- fields` and the
runtime leg (the pack imports the machine layer; nothing here touches it). The
specs, `limits:check` and `prepush` ran and are green. **No conformance leg was
played**: the station is held by a runtime measurement under `incus-ovn`, and
the owner plays the pass once on the assembled lot. What `octl` and `fields`
would prove here: that `oapi-cli`, `octl` and the Terraform provider still read
images and snapshots with one more key on each object, and that the shapes gate
does not name `AccountAlias` on a read that now carries it.

One harness observation, not this change's: under `prepush`'s parallel
`go test -race ./...`, `TestTheDay2ReaderControlFindsABrokenComparator`
(`tools/conformance`) went red once with the control's *other* verdict
("cannot find a planted value"), and passed 3/3 alone on this worktree and on
untouched `main`; the second `prepush` was green. Load-dependent, and nothing
in this diff touches `tools/conformance`. Reported here so it is not
attributed to the next change that meets it.

## Type of change

- [x] A route added or changed (two reads accept a filter they refused; every
      image and snapshot carries `AccountAlias`)
- [x] Bug fix
- [ ] Refactor
- [x] Documentation (`docs/limits.md`)
- [ ] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, through `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: untouched
- [x] Nothing in the diff could be written identically for another provider:
      the filter, the alias and the owner decision are this API's
- [x] `mise run testplan` was run, and what it printed was run except the
      conformance legs, named above with why and what they would prove

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **not run**, deliberately, see
      above; written here rather than ticked
- [x] Every field name in the diff comes from the provider's API description:
      `AccountAliases` from `FiltersImage` / `FiltersSnapshot`, `AccountAlias`
      from the `Image` and `Snapshot` schemas (`contracts/outscale.json`), and
      `Images[].AccountAlias` is in the recorded shapes of the real cloud

### When a route is added or changed — otherwise N/A

- [x] The routes keep their upstream operations; none is added
- [ ] `mise run conformance` passes — **not run**, see above. The unit tests
      hold the answers to the contract (`call` validates every response
      against `contracts/outscale.json`); the `octl` and `fields` legs are owed
- [x] The response was validated against the provider's own API description:
      through `contractDoc(t)` in both new tests, and the pre-commit hook
      "routes match the provider's API description" is green
- [x] What the client sends is read, or refused: the filter is declared in both
      `filterSpec` tables and compared in both matchers; an unknown filter is
      still refused by `refuseFilters`
- [x] `mise run drift:update`: N/A, no operation changed hands; `drift:check`
      green through `prepush`

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: a subsection under the catalogue section
      records that the catalogue is the emulated account's, so `[Outscale]`
      selects nothing and `self` is not accepted; `mise run limits:check` green
- [x] The README's generated tables: `feint docs --check` green through
      `prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: no runtime, no `FEINT_VM`, no container started.

## Related issues

Closes #700
