### PR TITLE
fix(exoscale): a validation refusal carries its errors array (#397)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -330,6 +330,18 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un refus de validation Exoscale porte son tableau `errors`** (#397).
+  `exoscale/v2.create-private-network` et `exoscale/v2.update-private-network`
+  refusaient une plage déclarée à l'envers, ou à moitié, ou une création sans
+  nom, avec `{"message": …}` seul, là où l'enregistrement du 2026-08-21
+  (`corpus/exoscale/exo-refusals.jsonl`, un vrai compte ch-gva-2) montre
+  `{"message": …, "errors": [{"message": …}]}` sur les deux 400 enregistrés.
+  Le même enregistrement montre cinq 404 et un 409 sans le tableau : c'est la
+  forme d'un échec de validation et non celle d'une erreur, et elle n'est
+  écrite que sur ces refus. Un 404 porte toujours le message et rien d'autre,
+  et un test tient cette moitié. L'exemption du corpus qui nommait cette issue
+  est retirée, et `feint corpus --check` compare désormais les deux échanges
+  enregistrés au lieu de les excuser.
 - **`osc/Client.ReadImages` et `osc/Client.ReadSnapshots` servent
   `Filters.AccountAliases`** (#700), le filtre que l'exemple `ReadImages` du
   contrat utilise lui-même. Les deux lectures le refusaient avec le 4001 qui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,18 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **An Exoscale validation refusal carries its `errors` array** (#397).
+  `exoscale/v2.create-private-network` and `exoscale/v2.update-private-network`
+  refused a range declared backwards, or half declared, or a create with no
+  name, with `{"message": …}` alone, where the recording of 2026-08-21
+  (`corpus/exoscale/exo-refusals.jsonl`, a real ch-gva-2 account) shows
+  `{"message": …, "errors": [{"message": …}]}` on both recorded 400s. The
+  same recording shows five 404s and one 409 without the array, so it is the
+  shape of a validation failure and not of an error, and it is written on
+  those refusals alone: a 404 still carries the message and nothing else,
+  and a test holds that half. The corpus exemption naming this issue is gone,
+  and `feint corpus --check` now compares the two recorded exchanges rather
+  than excusing them.
 - **`osc/Client.ReadImages` and `osc/Client.ReadSnapshots` serve
   `Filters.AccountAliases`** (#700), the filter the contract's own `ReadImages`
   example uses. Both reads refused it with the 4001 that names what they

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -278,14 +278,6 @@
   ],
   "accepted": [
     {
-      "file": "exoscale/exo-refusals.jsonl",
-      "operation": "exoscale/v2.create-private-network",
-      "kind": "absent",
-      "path": "errors",
-      "reason": "The status and the refusal are right and the body is short one key: the cloud carries an errors array naming the field it refused, this emulator carries the message alone. Adding the array unconditionally would put an empty one on the refusals the cloud answers without it, so a fix waits for a recording that shows both shapes.",
-      "issue": "https://github.com/stephrobert/feint/issues/397"
-    },
-    {
       "file": "outscale/oapi-cli-lb-shapes.jsonl",
       "operation": "osc/Client.DeleteLoadBalancer",
       "kind": "absent",

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -1573,6 +1573,29 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	emulator.WriteJSON(w, status, map[string]any{"message": message})
 }
 
+// writeValidationError is the refusal of a field's value, and it carries the
+// errors array writeError does not (#397).
+//
+// corpus/exoscale/exo-refusals.jsonl, recorded 2026-08-21 against a real
+// ch-gva-2 account: the two 400s of create-private-network with a range
+// declared backwards answer {"message": …, "errors": [{"message": …}]}; the
+// five 404s and the one 409 of the same recording answer {"message": …} alone.
+// So the array is the shape of a validation failure and not of an error, and
+// it is written here rather than in writeError, where it would put an empty
+// array on six answers the cloud gives without one. The texts are redacted in
+// the recording; the item carries the same sentence as the message, which is
+// the one thing this emulator knows about the field it refused.
+//
+// TestARangeRefusalCarriesItsErrorsArray fails without this on every
+// validation it names; TestARefusalThatIsNotAValidationCarriesNoErrorsArray
+// fails the day writeError grows the array.
+func writeValidationError(w http.ResponseWriter, message string) {
+	emulator.WriteJSON(w, http.StatusBadRequest, map[string]any{
+		"message": message,
+		"errors":  []map[string]any{{"message": message}},
+	})
+}
+
 // Env implements emulator.Pack.
 //
 // This is the provider where an environment is not enough, and the Note field

--- a/internal/providers/exoscale/privatenetworks.go
+++ b/internal/providers/exoscale/privatenetworks.go
@@ -186,7 +186,7 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 		name = *req.Name
 	}
 	if name == "" {
-		writeError(w, http.StatusBadRequest, "name is required")
+		writeValidationError(w, "name is required")
 		return
 	}
 	if strings.ContainsAny(name+stringOf(req.Description), "\n\r\x00") {
@@ -195,7 +195,9 @@ func (p *Pack) createPrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	dhcp, managed, err := managedRangeOf(stringOf(req.StartIP), stringOf(req.EndIP), stringOf(req.Netmask))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		// The recorded refusal (#397): a range declared backwards answers the
+		// validation shape, errors array included.
+		writeValidationError(w, err.Error())
 		return
 	}
 
@@ -476,7 +478,7 @@ func (p *Pack) updatePrivateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	dhcp, managed, err := managedRangeOf(startIP, endIP, netmask)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeValidationError(w, err.Error())
 		return
 	}
 	oldRange, wasManaged := rangeOf(res)

--- a/internal/providers/exoscale/validation_errors_test.go
+++ b/internal/providers/exoscale/validation_errors_test.go
@@ -1,0 +1,83 @@
+package exoscale_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// A validation refusal carries an errors array (#397).
+//
+// corpus/exoscale/exo-refusals.jsonl, recorded 2026-08-21 against a real
+// ch-gva-2 account, holds two POST /v2/private-network refusals with the range
+// declared backwards, both 400 with {"message": …, "errors": [{"message": …}]},
+// and five 404s (get-ssh-key, delete-ssh-key) and one 409 (register-ssh-key)
+// with {"message": …} alone. So the array is the validation shape, not the
+// error shape: it goes on a refusal of a field's value and nowhere else, and
+// adding it to writeError would have put an empty one on the six refusals the
+// cloud answers without it, the second divergence #397 warned about.
+//
+// The texts are redacted in the recording, so nothing here holds a wording:
+// the assertions are on the keys and their types, which is what the record
+// proves.
+
+// aValidationRefusal holds a 400 to the recorded shape: a top-level message
+// and a non-empty errors array whose items carry a message.
+func aValidationRefusal(t *testing.T, what string, code int, body map[string]any) {
+	t.Helper()
+	if code != http.StatusBadRequest {
+		t.Fatalf("%s answered %d: %v", what, code, body)
+	}
+	if message, _ := body["message"].(string); message == "" {
+		t.Errorf("%s: the refusal carries no top-level message: %v", what, body)
+	}
+	errs, ok := body["errors"].([]any)
+	if !ok || len(errs) == 0 {
+		t.Errorf("%s: the refusal carries no errors array, and the cloud's does: %v", what, body)
+		return
+	}
+	for i, entry := range errs {
+		item, _ := entry.(map[string]any)
+		if message, _ := item["message"].(string); message == "" {
+			t.Errorf("%s: errors[%d] carries no message: %v", what, i, entry)
+		}
+	}
+}
+
+func TestARangeRefusalCarriesItsErrorsArray(t *testing.T) {
+	h := serve(t)
+	for _, c := range []struct{ name, body string }{
+		{"end-ip below start-ip",
+			`{"name":"pn-backwards","start-ip":"10.90.0.20","end-ip":"10.90.0.10","netmask":"255.255.255.0","options":{}}`},
+		{"half a range",
+			`{"name":"pn-half","start-ip":"10.90.0.20","options":{}}`},
+		{"no name",
+			`{"start-ip":"10.90.0.20","end-ip":"10.90.0.200","netmask":"255.255.255.0","options":{}}`},
+	} {
+		rec, body := call(t, h, "POST", "/v2/private-network", c.body)
+		aValidationRefusal(t, "create with "+c.name, rec.Code, body)
+	}
+
+	// The update validates the same triple, and answers the same shape.
+	id := createTestNetwork(t, h, managedNetworkBody, "pn-managed")
+	rec, body := call(t, h, "PUT", "/v2/private-network/"+id,
+		`{"start-ip":"10.90.0.200","end-ip":"10.90.0.20","netmask":"255.255.255.0"}`)
+	aValidationRefusal(t, "update with end-ip below start-ip", rec.Code, body)
+}
+
+// The array is the validation shape and not the error shape: a refusal that is
+// not about a field's value carries the message alone, as the five 404s and the
+// 409 of the same recording do. Without this half, an errors array on every
+// refusal would pass the test above and be the second divergence.
+func TestARefusalThatIsNotAValidationCarriesNoErrorsArray(t *testing.T) {
+	h := serve(t)
+	rec, body := call(t, h, "GET", "/v2/private-network/00000000-0000-4000-8000-000000000000", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("an unknown network answered %d: %v", rec.Code, body)
+	}
+	if message, _ := body["message"].(string); message == "" {
+		t.Errorf("the 404 carries no message: %v", body)
+	}
+	if errs, present := body["errors"]; present {
+		t.Errorf("the 404 carries an errors array the cloud's does not: %v", errs)
+	}
+}

--- a/tools/falsify/specs/a-validation-refusal-carries-its-errors.json
+++ b/tools/falsify/specs/a-validation-refusal-carries-its-errors.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/exoscale/",
+  "mutations": [
+    {
+      "label": "the create's range refusal goes back to the bare message, which is #397 verbatim",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\tdhcp, managed, err := managedRangeOf(stringOf(req.StartIP), stringOf(req.EndIP), stringOf(req.Netmask))\n\tif err != nil {\n\t\t// The recorded refusal (#397): a range declared backwards answers the\n\t\t// validation shape, errors array included.\n\t\twriteValidationError(w, err.Error())",
+      "replace": "\tdhcp, managed, err := managedRangeOf(stringOf(req.StartIP), stringOf(req.EndIP), stringOf(req.Netmask))\n\tif err != nil {\n\t\t// The recorded refusal (#397): a range declared backwards answers the\n\t\t// validation shape, errors array included.\n\t\twriteError(w, http.StatusBadRequest, err.Error())\n\t\t_ = writeValidationError",
+      "test": "TestARangeRefusalCarriesItsErrorsArray"
+    },
+    {
+      "label": "the update's range refusal goes back to the bare message, so the same validation answers two shapes",
+      "file": "internal/providers/exoscale/privatenetworks.go",
+      "find": "\tdhcp, managed, err := managedRangeOf(startIP, endIP, netmask)\n\tif err != nil {\n\t\twriteValidationError(w, err.Error())",
+      "replace": "\tdhcp, managed, err := managedRangeOf(startIP, endIP, netmask)\n\tif err != nil {\n\t\twriteError(w, http.StatusBadRequest, err.Error())\n\t\t_ = writeValidationError",
+      "test": "TestARangeRefusalCarriesItsErrorsArray"
+    },
+    {
+      "label": "every refusal grows an errors array, which puts an empty one on the six answers the cloud gives without it: the second divergence #397 warned about",
+      "file": "internal/providers/exoscale/pack.go",
+      "find": "\temulator.WriteJSON(w, status, map[string]any{\"message\": message})",
+      "replace": "\temulator.WriteJSON(w, status, map[string]any{\"message\": message, \"errors\": []map[string]any{}})",
+      "test": "TestARefusalThatIsNotAValidationCarriesNoErrorsArray"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`corpus/exoscale/exo-refusals.jsonl`, recorded 2026-08-21 against a real
ch-gva-2 account, holds two `POST /v2/private-network` refusals with the range
declared backwards, both 400 with `{"message": …, "errors": [{"message": …}]}`.
This emulator answered the same 400 with `{"message": …}` alone. **Measured
before the fix**, on `main` at e0abc93, with the tests this pull request adds:

```text
create, end-ip below start-ip     {message} alone, no errors array
create, half a range               same
create, no name                    same
update, end-ip below start-ip      same
```

THE ARRAY IS THE VALIDATION SHAPE, NOT THE ERROR SHAPE.

#397's caution was that adding the array to `writeError` unconditionally would
put an empty one on refusals the cloud answers without it, and it asked for a
recording showing both shapes. The corpus already holds both: the same
recording has five 404s (`get-ssh-key`, `delete-ssh-key`) and one 409
(`register-ssh-key`) with `{"message": …}` and no array. So
`writeValidationError` exists beside `writeError`, carries the array, and is
called on the refusals of a field's value in the private network handlers: the
range triple on create and on update, and a create with no name. A 404 still
answers the message alone, `TestARefusalThatIsNotAValidationCarriesNoErrorsArray`
holds that half, and the mutation that grows `writeError` an empty array goes
red on it.

The texts are redacted in the recording, so the item carries the same sentence
as the message, the one thing this emulator knows about the field it refused;
nothing asserts a wording.

WHAT STAYS BARE, AND THE ONE THING HERE TO OBJECT TO.

The other 400s of this pack keep the bare message: a decode failure, the
emulator's own guards (control characters, the runtime refusing a block, the
inet4-only pool) and the validations of other resources, none of which the
corpus has recorded. They are one call away the day a recording shows them; the
alternative, converting every 400 in the pack on one resource's evidence, is
the divergence the issue warned about from the other side.

The corpus exemption naming this issue is removed, and `feint corpus --check`
compares the two recorded exchanges: 0 divergent findings nothing accepts. Three
mutations bite.

WHAT WAS NOT PLAYED, WRITTEN DOWN.

`mise run testplan` earned `conformance:leg -- exo-cli` and
`conformance:leg -- fields` for this pack. `prepush` and `corpus:check` are
green. **No conformance leg was played**: the station is held by a runtime
measurement under `incus-ovn`, and the owner plays the pass once on the
assembled lot. What the legs would prove: that `exo` and the Exoscale Terraform
suite never meet these refusals (they send valid ranges), and that the omission
gate does not name `errors` on a 400 it now carries.

## Type of change

- [x] A route added or changed (an error shape a client can observe)
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, through `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: untouched
- [x] Nothing in the diff could be written identically for another provider:
      the envelope is Exoscale's, measured on its wire
- [x] `mise run testplan` was run, and what it printed was run except the
      conformance legs, named above with why and what they would prove

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **not run**, deliberately, see
      above; written here rather than ticked
- [x] Every field name in the diff comes from a run of the real client:
      `errors` and `errors[].message` are in `corpus/exoscale/exo-refusals.jsonl`,
      seq 3 and 5

### When a route is added or changed — otherwise N/A

- [x] The routes keep their upstream operations; none is added
- [ ] `mise run conformance` passes — **not run**, see above; the corpus replay
      (`feint corpus --check`) compares the recorded exchanges and is green
- [x] The response was validated against the recording of the provider's own
      answer, which is the only description of this shape (the OpenAPI document
      declares no error schema)
- [x] What the client sends is read, or refused: unchanged
- [x] `mise run drift:update`: N/A, no operation changed hands

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md`: no limit moved; the divergence was recorded in
      `corpus/accepted.json`, and that record is gone with the divergence
- [x] The README's generated tables: `feint docs --check` green through
      `prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: no runtime, no `FEINT_VM`, no container started.

## Related issues

Closes #397

## Conformance

Conformance, played on the owner's station on 2026-09-06 against the **assembled lot** (#700, #397, #396, #395, #124 cherry-picked onto `main` at bd935a8, `feint corpus --check` green with six exemptions fewer), `FEINT_VM` off:

- `mise run conformance`: every suite passed (scw CLI, tofu, octl with the corrected refusal probe, the Outscale tofu stack, the three example stacks applied, re-planned empty and destroyed, the quick start, tofu and exo on the Exoscale pack, exo on ch-gva-2, fault injection, the recorded refusals, `feint up`/`down`, the network suites, the balancer dataplane). Score: **375 of 395 routes proven by a real client**. 0 `FAIL`, finished in 324 s.
- `mise run conformance:leg -- fields`, the one leg where the omission gate judges: green, exit 0, score 370 of 395, 0 `FAIL`, and the omission gate named no field (225 s).

One observation that is not this lot's: the `scw` CLI prints `runtime error: invalid memory address or nil pointer dereference` during the "load balancer chain" step, the suite tolerates it, and the same line is in `main`'s last green CI run (2026-09-06 10:09, three occurrences). Worth its own issue; not opened here.
