### PR TITLE
fix(outscale): ReadVms alone refuses a VmIds value that is not an identifier (#396)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -367,6 +367,19 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **`osc/Client.ReadVms` refuse une valeur de `VmIds` qui n'est pas un
+  identifiant** (#396), comme le vrai compte, et comme aucune autre lecture.
+  L'enregistrement du 2026-08-21 (`corpus/outscale/oapi-cli-refusals.jsonl`)
+  a envoyé `["not-an-identifier"]` à dix-sept lectures : `ReadVms` a répondu
+  400 avec `Errors [{Code 4104, Type InvalidParameterValue, Details "the
+  provided value does not respect the expected ID prefix"}]`, et les seize
+  autres 200 avec une liste vide. Cet émulateur répondait 200 aux dix-sept.
+  Il refuse désormais sur `ReadVms` seul, avec le code enregistré, et un test
+  envoie la même valeur à chaque filtre d'identifiants déclaré de chaque autre
+  lecture, `VmIds` de `ReadVmsState` compris, et tient leur 200 : l'asymétrie
+  est celle de l'amont, la reproduire sur une lecture est le correctif, sur
+  dix-sept ce serait seize divergences nouvelles. Les deux exemptions du
+  corpus qui nommaient cette issue sont retirées.
 - **Un refus de validation Exoscale porte son tableau `errors`** (#397).
   `exoscale/v2.create-private-network` et `exoscale/v2.update-private-network`
   refusaient une plage déclarée à l'envers, ou à moitié, ou une création sans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,19 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **`osc/Client.ReadVms` refuses a `VmIds` value that is not an identifier**
+  (#396), as the real account does and as no other read does. The recording
+  of 2026-08-21 (`corpus/outscale/oapi-cli-refusals.jsonl`) sent
+  `["not-an-identifier"]` to seventeen reads: `ReadVms` answered 400 with
+  `Errors [{Code 4104, Type InvalidParameterValue, Details "the provided
+  value does not respect the expected ID prefix"}]`, and the sixteen others
+  answered 200 and an empty list. This emulator answered 200 on all
+  seventeen. It now refuses on `ReadVms` alone, with the recorded code, and a
+  test sends the same value to every declared identifier filter of every
+  other read, `ReadVmsState`'s `VmIds` included, and holds their 200: the
+  asymmetry is upstream's, and reproducing it on one read is the fix, on
+  seventeen it would be sixteen new divergences. The two corpus exemptions
+  naming this issue are gone.
 - **An Exoscale validation refusal carries its `errors` array** (#397).
   `exoscale/v2.create-private-network` and `exoscale/v2.update-private-network`
   refused a range declared backwards, or half declared, or a create with no

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -575,22 +575,6 @@
     },
     {
       "file": "outscale/oapi-cli-refusals.jsonl",
-      "operation": "osc/Client.ReadVms",
-      "kind": "absent",
-      "path": "Errors",
-      "reason": "ReadVms is the only one of seventeen Outscale reads that refuses a filter value which is not an identifier; the other sixteen answer 200 with an empty list, measured in the same run. Reproducing a one-operation inconsistency is a decision, and validating all seventeen would be wrong sixteen times.",
-      "issue": "https://github.com/stephrobert/feint/issues/396"
-    },
-    {
-      "file": "outscale/oapi-cli-refusals.jsonl",
-      "operation": "osc/Client.ReadVms",
-      "kind": "status",
-      "path": "",
-      "reason": "ReadVms is the only one of seventeen Outscale reads that refuses a filter value which is not an identifier; the other sixteen answer 200 with an empty list, measured in the same run. Reproducing a one-operation inconsistency is a decision, and validating all seventeen would be wrong sixteen times.",
-      "issue": "https://github.com/stephrobert/feint/issues/396"
-    },
-    {
-      "file": "outscale/oapi-cli-refusals.jsonl",
       "operation": "osc/Client.UpdateImage",
       "kind": "status",
       "path": "",

--- a/internal/providers/outscale/errors.go
+++ b/internal/providers/outscale/errors.go
@@ -23,6 +23,12 @@ const (
 	// codeInvalidParameter covers a malformed or missing argument. No SDK helper
 	// classifies this range, so the number carries no behaviour.
 	codeInvalidParameter = "4001"
+	// codeInvalidIDPrefix is the one code of this file read off the wire rather
+	// than chosen for a range: corpus/outscale/oapi-cli-refusals.jsonl,
+	// 2026-08-21, ReadVms with a VmIds value that is not an identifier answers
+	// 400 and Errors [{Code 4104, Type InvalidParameterValue, Details "the
+	// provided value does not respect the expected ID prefix"}] (#396).
+	codeInvalidIDPrefix = "4104"
 	// codeResourceNotFound sits in 5000-5999 so osc.IsNotFound reports true.
 	codeResourceNotFound = "5063"
 	// codeImageDoesNotExist is what the real cloud answers CreateVms on an

--- a/internal/providers/outscale/export_test.go
+++ b/internal/providers/outscale/export_test.go
@@ -35,7 +35,15 @@ func DeclaredFilters() map[string][]DeclaredFilter {
 	for action, specs := range filtersByAction {
 		row := make([]DeclaredFilter, 0, len(specs))
 		for _, spec := range specs {
-			row = append(row, DeclaredFilter{Name: spec.Name, Absent: absentValue(spec.Kind)})
+			absent := absentValue(spec.Kind)
+			// ReadVms refuses a VmIds value that is not an identifier (#396,
+			// measured on that read alone), so the value nothing carries has to
+			// wear the prefix there, or the sweep would be refused rather than
+			// answered empty.
+			if action == "ReadVms" && spec.Name == "VmIds" {
+				absent = `["i-` + impossibleText + `"]`
+			}
+			row = append(row, DeclaredFilter{Name: spec.Name, Absent: absent})
 		}
 		out[action] = row
 	}

--- a/internal/providers/outscale/readvms_prefix_test.go
+++ b/internal/providers/outscale/readvms_prefix_test.go
@@ -1,0 +1,105 @@
+package outscale_test
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/providers/outscale"
+)
+
+// ReadVms alone refuses a filter value that is not an identifier (#396).
+//
+// corpus/outscale/oapi-cli-refusals.jsonl, recorded 2026-08-21 against a real
+// account: ReadVms with Filters.VmIds ["not-an-identifier"] answers 400 and
+// Errors [{Code "4104", Type "InvalidParameterValue", Details "the provided
+// value does not respect the expected ID prefix"}]. The same probe on sixteen
+// other reads answered 200 and an empty list in the same run. The asymmetry is
+// upstream's and measured, which is why the check lives in readVms and in no
+// shared layer: an emulator that validated all seventeen would be wrong sixteen
+// times. The second test below is the sixteen.
+
+func TestReadVmsRefusesAFilterValueThatIsNotAnIdentifier(t *testing.T) {
+	ts := newServer(t)
+	inventory(t, ts)
+
+	status, out := post(t, ts, "ReadVms", `{"Filters":{"VmIds":["not-an-identifier"]}}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("a VmIds value with no identifier prefix answered %d: %v", status, out)
+	}
+	errs, _ := out["Errors"].([]any)
+	if len(errs) != 1 {
+		t.Fatalf("the refusal carries %d errors, want the recorded one: %v", len(errs), out)
+	}
+	first, _ := errs[0].(map[string]any)
+	if first["Code"] != "4104" || first["Type"] != "InvalidParameterValue" {
+		t.Errorf("the refusal is %v/%v, and the recording says 4104/InvalidParameterValue", first["Code"], first["Type"])
+	}
+	if details, _ := first["Details"].(string); !strings.Contains(details, "ID prefix") {
+		t.Errorf("the refusal does not name the prefix: %q", details)
+	}
+
+	// The accepting halves, without which a guard refusing every VmIds value
+	// would pass the assertions above: a real identifier selects its machine,
+	// and an identifier nothing carries selects nothing with a 200.
+	_, all := post(t, ts, "ReadVms", `{}`)
+	vms, _ := all["Vms"].([]any)
+	if len(vms) == 0 {
+		t.Fatal("inventory created no Vm; nothing here can be selected")
+	}
+	id, _ := vms[0].(map[string]any)["VmId"].(string)
+	status, out = post(t, ts, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)
+	if selected, _ := out["Vms"].([]any); status != http.StatusOK || len(selected) != 1 {
+		t.Errorf("a real VmId answered %d and %d machines: %v", status, len(selected), out)
+	}
+	status, out = post(t, ts, "ReadVms", `{"Filters":{"VmIds":["i-00000000"]}}`)
+	if selected, _ := out["Vms"].([]any); status != http.StatusOK || len(selected) != 0 {
+		t.Errorf("an identifier nothing carries answered %d and %d machines: %v", status, len(selected), out)
+	}
+}
+
+// The other reads keep answering 200 on the same value: the refusal is
+// ReadVms's alone, as measured, and not a rule. Every declared identifier
+// filter of every other read is sent the value the cloud refused on ReadVms,
+// and ReadVmsState with the very same filter name is among them.
+func TestEveryOtherReadAcceptsAFilterValueThatIsNotAnIdentifier(t *testing.T) {
+	ts := newServer(t)
+	inventory(t, ts)
+
+	declared := outscale.DeclaredFilters()
+	actions := make([]string, 0, len(declared))
+	for action := range declared {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+
+	witnessed := 0
+	vmsState := false
+	for _, action := range actions {
+		if action == "ReadVms" {
+			continue
+		}
+		for _, filter := range declared[action] {
+			if !strings.HasSuffix(filter.Name, "Ids") {
+				continue
+			}
+			status, out := post(t, ts, action, `{"Filters":{"`+filter.Name+`":["not-an-identifier"]}}`)
+			if status != http.StatusOK {
+				t.Errorf("%s %s [not-an-identifier] answered %d, and the cloud answers 200 on every read but ReadVms: %v",
+					action, filter.Name, status, out)
+				continue
+			}
+			witnessed++
+			if action == "ReadVmsState" && filter.Name == "VmIds" {
+				vmsState = true
+			}
+		}
+	}
+	if witnessed < 10 {
+		t.Fatalf("only %d identifier filters were asked; the sixteen reads of the recording carry more than that", witnessed)
+	}
+	if !vmsState {
+		t.Fatal("ReadVmsState's VmIds was not asked, and it is the filter name the refusal is about on the other read")
+	}
+}

--- a/internal/providers/outscale/vms.go
+++ b/internal/providers/outscale/vms.go
@@ -173,6 +173,27 @@ func (p *Pack) readVms(w http.ResponseWriter, r *http.Request) {
 	if p.refuseFilters(w, req.Filters, vmFilters) {
 		return
 	}
+	// ReadVms alone refuses a VmIds value that is not an identifier (#396).
+	//
+	// Measured, not deduced: the same probe, ["not-an-identifier"], was sent
+	// to seventeen reads of a real account on 2026-08-21
+	// (corpus/outscale/oapi-cli-refusals.jsonl), and this is the only one the
+	// cloud refused; the sixteen others answered 200 and an empty list. So the
+	// check lives here and in no shared layer, on purpose: an emulator that
+	// validated all seventeen would be wrong sixteen times. The prefix is the
+	// one the refusal names, and the one this pack mints (newVMID).
+	// TestReadVmsRefusesAFilterValueThatIsNotAnIdentifier fails without this;
+	// TestEveryOtherReadAcceptsAFilterValueThatIsNotAnIdentifier fails the day
+	// it spreads.
+	if ids, present, _ := req.Filters.strings("VmIds"); present {
+		for _, id := range ids {
+			if !strings.HasPrefix(id, "i-") {
+				p.writeError(w, http.StatusBadRequest, codeInvalidIDPrefix, typeInvalidParameter,
+					"the provided value does not respect the expected ID prefix")
+				return
+			}
+		}
+	}
 
 	vms := make([]map[string]any, 0)
 	for _, res := range p.env.Store.List(kindVM, resource.Tenant{Provider: Name}) {

--- a/tools/falsify/specs/read-vms-refuses-a-value-that-is-not-an-identifier.json
+++ b/tools/falsify/specs/read-vms-refuses-a-value-that-is-not-an-identifier.json
@@ -1,0 +1,26 @@
+{
+  "package": "./internal/providers/outscale/",
+  "mutations": [
+    {
+      "label": "the prefix check never fires, and ReadVms answers 200 and an empty list on a value the cloud refuses, which is #396 verbatim",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\t\t\tif !strings.HasPrefix(id, \"i-\") {",
+      "replace": "\t\t\tif !strings.HasPrefix(id, \"i-\") && false {",
+      "test": "TestReadVmsRefusesAFilterValueThatIsNotAnIdentifier"
+    },
+    {
+      "label": "the check refuses the prefix this pack mints, so a real identifier is refused along with the fake one",
+      "file": "internal/providers/outscale/vms.go",
+      "find": "\t\t\tif !strings.HasPrefix(id, \"i-\") {",
+      "replace": "\t\t\tif !strings.HasPrefix(id, \"vm-\") {",
+      "test": "TestReadVmsRefusesAFilterValueThatIsNotAnIdentifier"
+    },
+    {
+      "label": "the refusal carries the pack's default code instead of the one read off the wire, so a client keyed on 4104 sees a different refusal",
+      "file": "internal/providers/outscale/errors.go",
+      "find": "\tcodeInvalidIDPrefix = \"4104\"",
+      "replace": "\tcodeInvalidIDPrefix = \"4001\"",
+      "test": "TestReadVmsRefusesAFilterValueThatIsNotAnIdentifier"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

`corpus/outscale/oapi-cli-refusals.jsonl`, recorded 2026-08-21 against a real
account, sent `Filters.VmIds ["not-an-identifier"]` to `ReadVms` and got 400
with `Errors [{Code 4104, Type InvalidParameterValue, Details "the provided
value does not respect the expected ID prefix"}]`. The same probe on sixteen
other reads answered 200 and an empty list, in the same run. This emulator
answered 200 and an empty list on all seventeen. **Measured before the fix**,
on `main` at e0abc93, with the tests this pull request adds:

```text
ReadVms {"Filters":{"VmIds":["not-an-identifier"]}}   200 {"Vms":[]}
```

WHAT THE MEASUREMENT ADDED: THE CODE.

#396 quotes the type and the sentence; the recording carries the code, `4104`,
which the issue does not, and which is not the `4001` this pack answers for
every other bad argument. It is the one code of `errors.go` read off the wire
rather than chosen for a range, and it is written down as such.

ONE READ, NOT A RULE. THE DECISION THE ISSUE ASKED FOR.

The issue asked whether to reproduce a one-operation inconsistency. Yes, and
narrowly: the check lives in `readVms` and nowhere shared, because the
asymmetry is upstream's and measured, and an emulator that validated all
seventeen would be wrong sixteen times.
`TestEveryOtherReadAcceptsAFilterValueThatIsNotAnIdentifier` sends the same
value to every declared identifier filter of every other read, taken from the
pack's own declarations, `ReadVmsState`'s `VmIds` included, and holds their
200: the day the check spreads, the test says where. The prefix is the one the
refusal names and the one this pack mints.

The exclusion sweep (`TestEveryDeclaredFilterCanExcludeSomething`) sends every
string filter a value nothing carries; on this one filter that value now wears
the prefix, or the sweep would be refused rather than answered empty.

The two corpus exemptions naming this issue are removed, and
`feint corpus --check` compares the recorded exchange: 0 divergent findings
nothing accepts. Three mutations bite: the check never fires, it refuses the
prefix this pack mints, it carries the default code.

WHAT WAS NOT PLAYED, WRITTEN DOWN.

`mise run testplan` earned `conformance:leg -- octl` and
`conformance:leg -- fields` for this pack. `prepush` and `corpus:check` are
green. **No conformance leg was played**: the station is held by a runtime
measurement under `incus-ovn`, and the owner plays the pass once on the
assembled lot. What the legs would prove: that `oapi-cli`, `octl` and the
Terraform provider still read machines (they send real identifiers; grep says
neither the conformance scripts nor the probe send `ReadVms` a `VmIds` value
without the prefix), and that the training survey's recordings still match.

## Type of change

- [x] A route added or changed (a read refuses what it accepted)
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, through `mise run prepush`
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider: untouched
- [x] Nothing in the diff could be written identically for another provider:
      the refusal is one Outscale read's, measured on its wire
- [x] `mise run testplan` was run, and what it printed was run except the
      conformance legs, named above with why and what they would prove

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **not run**, deliberately, see
      above; written here rather than ticked
- [x] Every field name and value in the diff comes from a run of the real
      client: `Errors[].Code 4104` is in `corpus/outscale/oapi-cli-refusals.jsonl`
      (the type and details are redacted there and quoted by the issue)

### When a route is added or changed — otherwise N/A

- [x] The routes keep their upstream operations; none is added
- [ ] `mise run conformance` passes — **not run**, see above; the corpus replay
      (`feint corpus --check`) compares the recorded exchange and is green
- [x] The response was validated against the provider's own API description:
      the pre-commit hook "routes match the provider's API description" is
      green, and the envelope is the pack's existing `Errors` shape
- [x] What the client sends is read, or refused: `VmIds` was read; a value that
      is not an identifier is refused, on this read alone
- [x] `mise run drift:update`: N/A, no operation changed hands

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md`: no limit moved; the divergence was recorded in
      `corpus/accepted.json`, and that record is gone with the divergence
- [x] The README's generated tables: `feint docs --check` green through
      `prepush`

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: no runtime, no `FEINT_VM`, no container started.

## Related issues

Closes #396

## Conformance

Conformance, played on the owner's station on 2026-09-06 against the **assembled lot** (#700, #397, #396, #395, #124 cherry-picked onto `main` at bd935a8, `feint corpus --check` green with six exemptions fewer), `FEINT_VM` off:

- `mise run conformance`: every suite passed (scw CLI, tofu, octl with the corrected refusal probe, the Outscale tofu stack, the three example stacks applied, re-planned empty and destroyed, the quick start, tofu and exo on the Exoscale pack, exo on ch-gva-2, fault injection, the recorded refusals, `feint up`/`down`, the network suites, the balancer dataplane). Score: **375 of 395 routes proven by a real client**. 0 `FAIL`, finished in 324 s.
- `mise run conformance:leg -- fields`, the one leg where the omission gate judges: green, exit 0, score 370 of 395, 0 `FAIL`, and the omission gate named no field (225 s).

One observation that is not this lot's: the `scw` CLI prints `runtime error: invalid memory address or nil pointer dereference` during the "load balancer chain" step, the suite tolerates it, and the same line is in `main`'s last green CI run (2026-09-06 10:09, three occurrences). Worth its own issue; not opened here.
