### PR TITLE
fix(corpus): no pack fixture lives in the namespace the sanitiser mints (#395)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -916,6 +916,28 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Modifié
 
+- **Les images du catalogue Outscale sont `ami-fe1a7001`, `ami-fe1a7002` et
+  `ami-fe1a7003`, et non plus `ami-00000001..3`** (#395) ; ses sept services
+  de point d'accès réseau sont `pl-fe1a7001..7`, et non plus
+  `pl-00000001..7` ; et le groupe de sécurité par défaut d'Exoscale est
+  `fe1a7000-0000-4000-8000-000000000001`, et non plus
+  `00000000-0000-4000-8000-000000000001`. Les trois vivaient dans
+  l'espace de noms que le sanitiseur de corpus frappe (`feint transcript
+  --sanitise` : les identifiants préfixés comme un compteur sur huit chiffres
+  hexadécimaux, les UUID sous `00000000-0000-4000-8000-`), si bien qu'un
+  enregistrement assaini pouvait nommer une fixture de cet émulateur là où il
+  désignait un objet du compte : mesuré sur
+  `corpus/outscale/oapi-cli-refusals.jsonl`, où `osc/Client.DeleteImage` et
+  `osc/Client.UpdateImage` sur une image que le cloud avait refusée en 400
+  étaient rejoués comme `ami-00000002`, trouvaient le catalogue, et répondaient
+  409 « belongs to the emulated catalogue ». Les deux exemptions du corpus qui
+  portaient cela sont retirées, et `feint corpus --check` compare les
+  échanges. Un test dans `internal/cli` lit chaque littéral de chaîne de la
+  source de chaque pack avec le reconnaisseur du sanitiseur lui-même, de sorte
+  qu'aucun pack ne peut y ramener une fixture. Un client qui avait écrit
+  `ami-00000001` en dur change une valeur ; le README, le quickstart et chaque
+  fixture de conformance l'ont fait.
+
 - **`instance/v1/API.ListVolumesTypes` reste refusée et sa raison est remplacée**
   (#625). L'ancienne disait qu'une liste de types « décrirait des capacités et
   des contraintes que rien ici ne peut honorer », ce qui ne pouvait pas être ce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -859,6 +859,26 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Changed
 
+- **The Outscale catalogue's images are `ami-fe1a7001`, `ami-fe1a7002` and
+  `ami-fe1a7003`, no longer `ami-00000001..3`** (#395); its seven net access
+  point services are `pl-fe1a7001..7`, no longer `pl-00000001..7`; and the
+  Exoscale default security group is `fe1a7000-0000-4000-8000-000000000001`,
+  no longer `00000000-0000-4000-8000-000000000001`. All three lived in the
+  namespace the
+  corpus sanitiser mints (`feint transcript --sanitise`: prefixed identifiers
+  as a counter in eight hexadecimal digits, UUIDs under
+  `00000000-0000-4000-8000-`), so a sanitised recording could name a fixture of
+  this emulator where it meant an object of the account: measured on
+  `corpus/outscale/oapi-cli-refusals.jsonl`, where `osc/Client.DeleteImage`
+  and `osc/Client.UpdateImage` on an image the cloud refused with 400 replayed
+  as `ami-00000002`, found the catalogue, and answered 409 "belongs to the
+  emulated catalogue". The two corpus exemptions carrying that are gone, and
+  `feint corpus --check` compares the exchanges. A test in `internal/cli`
+  reads every string literal of every pack's source with the sanitiser's own
+  recogniser, so no pack can move a fixture back in. A client that hardcoded
+  `ami-00000001` changes one value; the README, the quickstart and every
+  conformance fixture did.
+
 - **`instance/v1/API.ListVolumesTypes` stays declined and its reason is replaced**
   (#625). The old one said a type list "would describe capabilities and
   constraints nothing here can honour", which could not be what separates it from

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ cat > /tmp/osc.json <<'EOF'
 }
 EOF
 
-octl --config /tmp/osc.json -o raw iaas api CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2
+octl --config /tmp/osc.json -o raw iaas api CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c1r1p2
 octl --config /tmp/osc.json -o raw iaas api ReadVms
 ```
 

--- a/corpus/accepted.json
+++ b/corpus/accepted.json
@@ -566,22 +566,6 @@
       "issue": "https://github.com/stephrobert/feint/issues/392"
     },
     {
-      "file": "outscale/oapi-cli-refusals.jsonl",
-      "operation": "osc/Client.DeleteImage",
-      "kind": "status",
-      "path": "",
-      "reason": "THIS IS THE INSTRUMENT, NOT THE PACK. The sanitiser mints Outscale identifiers as a counter in eight hexadecimal digits, and the Outscale catalogue's own images are ami-00000001..3, so the recording's second prefixed value came out naming a catalogue image of this emulator: the refusal recorded against an image that does not exist replays against one that does, and answers 409 instead of 400. Nothing here is a measurement of the pack until the two namespaces are disjoint.",
-      "issue": "https://github.com/stephrobert/feint/issues/395"
-    },
-    {
-      "file": "outscale/oapi-cli-refusals.jsonl",
-      "operation": "osc/Client.UpdateImage",
-      "kind": "status",
-      "path": "",
-      "reason": "THIS IS THE INSTRUMENT, NOT THE PACK. The sanitiser mints Outscale identifiers as a counter in eight hexadecimal digits, and the Outscale catalogue's own images are ami-00000001..3, so the recording's second prefixed value came out naming a catalogue image of this emulator: the refusal recorded against an image that does not exist replays against one that does, and answers 409 instead of 400. Nothing here is a measurement of the pack until the two namespaces are disjoint.",
-      "issue": "https://github.com/stephrobert/feint/issues/395"
-    },
-    {
       "file": "scaleway/scw-billed-shapes.jsonl",
       "operation": "block/v1alpha1/API.DeleteSnapshot",
       "kind": "status",

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -653,7 +653,7 @@ feint serve --strict-catalog catalog.json
 ```json
 {
   "scaleway": {"images": ["debian_bookworm"], "types": ["DEV1-S", "PLAY2-PICO"]},
-  "outscale": {"images": ["ami-00000001"], "types": ["tinav6.c2r4p2"]},
+  "outscale": {"images": ["ami-fe1a7001"], "types": ["tinav6.c2r4p2"]},
   "exoscale": {"templates": ["11111111-1111-4111-8111-111111111111"], "types": ["21624abb-764e-4def-81d7-9fc54b5957fb"]}
 }
 ```
@@ -2003,9 +2003,12 @@ not from the emulator:
 
 | image | AMI | address carried after the create answered |
 |---|---|---|
-| `ubuntu:24.04` | `ami-00000001` | 27 ms, 32 ms |
-| `debian:12` | `ami-00000002` | 46 ms, 35 ms |
-| `alpine:3.21` | `ami-00000003` | **never** |
+| `ubuntu:24.04` | `ami-fe1a7001` | 27 ms, 32 ms |
+| `debian:12` | `ami-fe1a7002` | 46 ms, 35 ms |
+| `alpine:3.21` | `ami-fe1a7003` | **never** |
+
+(The three were `ami-00000001..3` when this was measured; #395 moved them out
+of the corpus sanitiser's minting space, and nothing about the boot changed.)
 
 `never` is measured, not inferred: six alpine machines, ceilings of 45 s, 90 s
 and 180 s, none of them carried it. Station of the maintainer, 2026-08-29,

--- a/examples/quickstart/outscale/main.tf
+++ b/examples/quickstart/outscale/main.tf
@@ -45,11 +45,11 @@ provider "outscale" {
 }
 
 resource "outscale_vm" "quickstart" {
-  # A catalogue OMI: ami-00000003 is one of the identifiers the emulator can
+  # A catalogue OMI: ami-fe1a7003 is one of the identifiers the emulator can
   # really boot. An unknown one applies fine with no machine runtime and is
   # refused the moment somebody turns one on, which is a first example teaching
   # a habit that breaks later.
-  image_id = "ami-00000003"
+  image_id = "ami-fe1a7003"
   vm_type  = "tinav6.c1r1p2"
 }
 

--- a/examples/stacks/outscale/feint.yaml
+++ b/examples/stacks/outscale/feint.yaml
@@ -14,7 +14,7 @@ emulator:
 
 runtime:
   mode: off
-  # ami-00000001, which the catalogue maps to ubuntu:24.04: what every Vm here
+  # ami-fe1a7001, which the catalogue maps to ubuntu:24.04: what every Vm here
   # boots once the mode above is not `off`. Checked before anything starts.
   images:
     - ubuntu/24.04

--- a/examples/stacks/surveyed.md
+++ b/examples/stacks/surveyed.md
@@ -875,7 +875,8 @@ and the API never mentions.
 It boots for one reason, and the reason has to be declared because it is a
 harness choice rather than a recorded one: the register names "nine TF_VARs
 (keys, region, vm type, image id, keypair name, three DNS IPs)" **without naming
-the image id**, so this replay supplied `ami-00000001`, an OMI the emulated
+the image id**, so this replay supplied `ami-00000001` (renamed `ami-fe1a7001`
+by #395, after this survey), an OMI the emulated
 catalogue holds. Same pack, same runtime, same evening as the four Outscale
 entries that started nothing on `ami-a3ca408c` / `ami-538af795` / `ami-47899c77`.
 The only variable that differs is whether the identifier is in the catalogue, and

--- a/internal/cli/declared_test.go
+++ b/internal/cli/declared_test.go
@@ -24,7 +24,7 @@ func TestServeRefusesADeclarationNamingAKindNoPackChecks(t *testing.T) {
 	}
 
 	// The typo: "image" for "images", on a pack that checks images and types.
-	_, err = loadDeclared(write("typo.json", `{"outscale": {"image": ["ami-00000001"]}}`), srv.Packs())
+	_, err = loadDeclared(write("typo.json", `{"outscale": {"image": ["ami-fe1a7001"]}}`), srv.Packs())
 	if err == nil {
 		t.Fatal("a declaration naming a kind no pack checks was accepted")
 	}
@@ -38,7 +38,7 @@ func TestServeRefusesADeclarationNamingAKindNoPackChecks(t *testing.T) {
 	// The accepting half: every kind of the three packs, as documented.
 	declared, err := loadDeclared(write("ok.json", `{
 		"scaleway": {"images": ["debian_bookworm"], "types": ["DEV1-S"]},
-		"outscale": {"images": ["ami-00000001"], "types": ["tinav6.c1r1p2"]},
+		"outscale": {"images": ["ami-fe1a7001"], "types": ["tinav6.c1r1p2"]},
 		"exoscale": {"templates": ["11111111-1111-4111-8111-111111111111"], "types": ["21624abb-764e-4def-81d7-9fc54b5957fb"]}
 	}`), srv.Packs())
 	if err != nil {

--- a/internal/cli/fixtures_test.go
+++ b/internal/cli/fixtures_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/feint/internal/corpus"
+)
+
+// No fixture of any pack lives in the namespace the corpus sanitiser mints
+// (#395).
+//
+// The sanitiser replaces the identifiers of a recording with a counter: UUIDs
+// under 00000000-0000-4000-8000-, addresses inside 198.18.0.0/15, and prefixed
+// identifiers as eight hexadecimal digits starting 00 (ami-00000001, …). A
+// pack fixture written in the same space is a value a recording can reach, and
+// then a replay names an object of THIS emulator where the recording named one
+// of the account: #395 measured DeleteImage on an image that did not exist,
+// refused by the cloud with 400, replayed as ami-00000002 — a catalogue image —
+// and refused here with 409 "belongs to the emulated catalogue", a plausible
+// verdict on a request nobody made. The Exoscale default security group was
+// the same class one UUID over: 00000000-0000-4000-8000-000000000001, the first
+// UUID every sanitised corpus hands out.
+//
+// So the rule is held across packs rather than by inspection of one catalogue:
+// every string literal of every non-test file under internal/providers is read
+// with the sanitiser's own recogniser, corpus.Minted, so the two cannot drift
+// apart. Test files are not scanned: a test legitimately names a minted-looking
+// identifier as "one that exists nowhere".
+//
+// The scan proves it can find before it reports nothing: a planted file with
+// one value of each family must be reported, or a scan that reads no literal
+// would pass by silence.
+
+// identifierLike picks, out of a string literal, the tokens the sanitiser could
+// have minted: a UUID, a prefixed identifier, a dotted quad.
+var identifierLike = regexp.MustCompile(
+	`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` +
+		`|\b[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-[0-9a-f]{8,}\b` +
+		`|\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+
+// mintedFixturesIn parses one Go file and returns every token of a string
+// literal the sanitiser would recognise as its own, with where it sits.
+func mintedFixturesIn(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	var found []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		for _, candidate := range identifierLike.FindAllString(value, -1) {
+			// A netmask is one of thirty-two values and the sanitiser maps
+			// that set onto itself, so corpus.Minted answers true for every
+			// one of them; it is not an identifier and is not what this
+			// test is about.
+			if ip := net.ParseIP(candidate); ip != nil && ip.To4() != nil {
+				if _, bits := net.IPMask(ip.To4()).Size(); bits != 0 {
+					continue
+				}
+			}
+			if corpus.Minted(candidate) {
+				found = append(found, fmt.Sprintf("%s:%d %q", filepath.Base(path), fset.Position(lit.Pos()).Line, candidate))
+			}
+		}
+		return true
+	})
+	return found, nil
+}
+
+func TestNoPackFixtureLivesInTheSanitisersMintingSpace(t *testing.T) {
+	// The witness: one value of each minted family, and one prefixed
+	// identifier outside the space, which must not be reported.
+	planted := filepath.Join(t.TempDir(), "planted.go")
+	source := "package planted\n\nvar fixtures = []string{\n" +
+		"\t\"ami-00000001\",\n" +
+		"\t\"00000000-0000-4000-8000-000000000001\",\n" +
+		"\t\"198.18.0.1\",\n" +
+		"\t\"ami-fe1a7001\",\n" +
+		"\t\"255.255.255.0\",\n" +
+		"}\n"
+	if err := os.WriteFile(planted, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	witnessed, err := mintedFixturesIn(planted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(witnessed) != 3 {
+		t.Fatalf("the planted file carries three minted values and the scan reports %d: %v", len(witnessed), witnessed)
+	}
+
+	root := repoRoot(t)
+	var problems []string
+	files := 0
+	err = filepath.WalkDir(filepath.Join(root, "internal", "providers"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files++
+		found, err := mintedFixturesIn(path)
+		if err != nil {
+			return err
+		}
+		for _, f := range found {
+			rel, _ := filepath.Rel(root, filepath.Dir(path))
+			problems = append(problems, filepath.Join(rel, f))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if files == 0 {
+		t.Fatal("no pack source was scanned: this test measured nothing")
+	}
+	sort.Strings(problems)
+	if len(problems) > 0 {
+		t.Errorf("%d pack fixture(s) live in the space the corpus sanitiser mints, so a sanitised "+
+			"recording can name them and a replay then measures this emulator's fixture where the "+
+			"recording named an object of the account:\n  %s", len(problems), strings.Join(problems, "\n  "))
+	}
+}

--- a/internal/core/emulator/resources_test.go
+++ b/internal/core/emulator/resources_test.go
@@ -133,7 +133,7 @@ func TestNoProviderViewSerializesRuntime(t *testing.T) {
 	// field — only that this test can write a map.
 	creates := []struct{ method, path, body string }{
 		{"POST", "/instance/v1/zones/fr-par-1/servers", `{"name":"demo","commercial_type":"DEV1-S"}`},
-		{"POST", "/api/v1/CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`},
+		{"POST", "/api/v1/CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2"}`},
 		{"POST", "/v2/instance", `{"name":"demo","instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},` +
 			`"template":{"id":"11111111-1111-4111-8111-111111111111"},"disk-size":10}`},
 	}

--- a/internal/providers/exoscale/securitygroups.go
+++ b/internal/providers/exoscale/securitygroups.go
@@ -26,7 +26,16 @@ const (
 
 	// defaultSecurityGroupID is stable across runs: a client that recorded it
 	// yesterday must find the same group today, the way it would upstream.
-	defaultSecurityGroupID = "00000000-0000-4000-8000-000000000001"
+	//
+	// Outside the UUID space the corpus sanitiser mints, deliberately (#395):
+	// that space is 00000000-0000-4000-8000-<counter>, and this group used to be
+	// its very first value, the one every sanitised recording of this pack
+	// hands to whatever UUID it met first. A fixture a recording can name is a
+	// replay that measures the fixture where the recording meant an object of
+	// the account. fe1a7… is the convention the Outscale catalogue uses for the
+	// same reason. TestNoPackFixtureLivesInTheSanitisersMintingSpace in
+	// internal/cli fails without this.
+	defaultSecurityGroupID = "fe1a7000-0000-4000-8000-000000000001"
 
 	// securityGroupVisibility is what every group of an emulated account
 	// answers. Their enum is private|public and public names the groups

--- a/internal/providers/outscale/audit_test.go
+++ b/internal/providers/outscale/audit_test.go
@@ -72,7 +72,7 @@ func TestConcurrentCreatesDoNotShareAnAddress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, out := post(t, ts, "CreateVms",
-				`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+				`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 			vms, _ := out["Vms"].([]any)
 			if len(vms) == 0 {
 				return
@@ -109,7 +109,7 @@ func TestASubnetDoesNotDeleteUnderAVm(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.43.0.0/16", "10.43.1.0/24")
 
-	post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 
 	status, out := post(t, ts, "DeleteSubnet", `{"SubnetId":"`+subnetID+`"}`)
 	if status == http.StatusOK {
@@ -134,7 +134,7 @@ func TestAFailedCreateLeavesNothingBehind(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.44.0.0/16", "10.44.1.0/28")
 
 	status, _ := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","MaxVmsCount":14,"BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","MaxVmsCount":14,"BootOnCreation":false}`)
 	if status == http.StatusOK {
 		t.Skip("the subnet was large enough; nothing to unwind")
 	}
@@ -191,7 +191,7 @@ func TestAvailableIpsCountFollowsTheMachines(t *testing.T) {
 	empty, _ := first["AvailableIpsCount"].(float64)
 
 	for range 3 {
-		post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	}
 
 	_, out = post(t, ts, "ReadSubnets", `{}`)
@@ -257,7 +257,7 @@ func TestDryRunReachesNoHandler(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.47.0.0/16", "10.47.1.0/24")
 
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -272,7 +272,7 @@ func TestDryRunReachesNoHandler(t *testing.T) {
 	}
 
 	// And the creating one.
-	if status, _ := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","DryRun":true}`); status != http.StatusOK {
+	if status, _ := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","DryRun":true}`); status != http.StatusOK {
 		t.Fatalf("dry run create: status %d", status)
 	}
 	_, out = post(t, ts, "ReadVms", `{}`)
@@ -313,7 +313,7 @@ func TestASubnetDoesNotDeleteUnderARace(t *testing.T) {
 			// placement and its Put. Still not wide enough to catch the missing
 			// lock, which is why the comment above says so.
 			post(t, ts, "CreateVms",
-				`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","MaxVmsCount":8,"BootOnCreation":false}`)
+				`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","MaxVmsCount":8,"BootOnCreation":false}`)
 		}()
 		go func() {
 			defer wg.Done()
@@ -368,7 +368,7 @@ func TestACreateWhoseResourceVanishesLeavesNoMachineBehind(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`"}`)
+		post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`"}`)
 	}()
 
 	// The machine is starting; empty the store under it.
@@ -506,7 +506,7 @@ func TestTwoConcurrentStartsReachTheRuntimeOnce(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.52.0.0/16", "10.52.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -552,7 +552,7 @@ func TestUpdateVmValidatesWhatCreateValidates(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.53.0.0/16", "10.53.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -764,7 +764,7 @@ func TestUpdateVmAndStartVmsDoNotOverwriteEachOther(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.57.0.0/16", "10.57.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -815,7 +815,7 @@ func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.58.0.0/16", "10.58.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -855,7 +855,7 @@ func TestABodyTheServerAcceptsReachesTheHandler(t *testing.T) {
 func TestAnUnsupportedFilterIsRefused(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.60.0.0/16", "10.60.1.0/24")
-	post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+	post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 
 	for _, probe := range []struct{ action, body string }{
 		{"ReadVms", `{"Filters":{"Architectures":["x86_64"]}}`},
@@ -1060,7 +1060,7 @@ func TestAStoppedVmKeepsItsPrivateAddress(t *testing.T) {
 	ts := newRuntimeServer(t, machine.Use(runtime))
 
 	// No Subnet: this is the case that had the address only in the binding.
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001"}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1100,7 +1100,7 @@ func TestReadAdminPasswordAnswersEmpty(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.62.0.0/16", "10.62.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1200,13 +1200,13 @@ func TestDeletionProtectionRefusesTheDelete(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.64.0.0/16", "10.64.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	plain, _ := vms[0].(map[string]any)
 	plainID, _ := plain["VmId"].(string)
 
 	_, out = post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false,"DeletionProtection":true}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false,"DeletionProtection":true}`)
 	vms, _ = out["Vms"].([]any)
 	guarded, _ := vms[0].(map[string]any)
 	guardedID, _ := guarded["VmId"].(string)
@@ -1240,7 +1240,7 @@ func TestResultsPerPageIsHonoured(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.65.0.0/16", "10.65.1.0/24")
 	for range 3 {
 		post(t, ts, "CreateVms",
-			`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+			`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	}
 
 	count := func(body string) int {
@@ -1270,7 +1270,7 @@ func TestATerminatedVmStaysReadable(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.66.0.0/16", "10.66.1.0/24")
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1364,7 +1364,7 @@ func TestAVolumeIsCreatedReadAndLinked(t *testing.T) {
 	}
 
 	_, out = post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
@@ -1431,7 +1431,7 @@ func TestAVolumeDoesNotShrink(t *testing.T) {
 func TestReadVmsStateAnswersRunningByDefault(t *testing.T) {
 	ts := newServer(t)
 	_, subnetID := netAndSubnet(t, ts, "10.68.0.0/16", "10.68.1.0/24")
-	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`"}`)
+	_, out := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/outscale/barrage_test.go
+++ b/internal/providers/outscale/barrage_test.go
@@ -108,7 +108,7 @@ func TestAnOutscaleBarrageLeavesTheStoreCoherent(t *testing.T) {
 				handed <- nestedID(ip, "PublicIp", "PublicIp")
 
 				status, vm := postRaw(ts, "CreateVms",
-					fmt.Sprintf(`{"ImageId":"ami-00000001","SubnetId":%q}`, subnetID))
+					fmt.Sprintf(`{"ImageId":"ami-fe1a7001","SubnetId":%q}`, subnetID))
 				if status != http.StatusOK {
 					problems <- fmt.Sprintf("%s-%d: CreateVms answered %d", tag, i, status)
 					continue

--- a/internal/providers/outscale/catalog.go
+++ b/internal/providers/outscale/catalog.go
@@ -250,13 +250,17 @@ const catalogueDate = "2025-01-01T00:00:00.000Z"
 //
 // The identifiers are deliberately outside the corpus sanitiser's minting
 // space. It hands out prefixed identifiers as a shared counter in eight
-// hexadecimal digits (internal/corpus/corpus.go), so ami-00000001..3 collide
-// with recorded values and #395 carries the two corpus exemptions that
-// collision costs. Numbering three more objects the same way would have widened
-// a known defect for no gain; fe1a7… is as valid an Outscale identifier and
-// cannot be reached by a small counter.
+// hexadecimal digits (internal/corpus/corpus.go), and the catalogue's images
+// were ami-fe1a7001..3 until #395: a recording's second prefixed value came
+// out of the sanitiser naming a catalogue image, and a DeleteImage the cloud
+// had refused with 400 replayed as a 409 "belongs to the emulated catalogue",
+// a plausible verdict on a request nobody made. The images moved to fe1a7…,
+// where these snapshots already were: as valid an Outscale identifier, and
+// one a small counter cannot reach.
 //
-// TestTheCatalogueIdentifiersStayOutOfTheMintingSpace fails without that choice.
+// TestTheCatalogueIdentifiersStayOutOfTheMintingSpace fails without that
+// choice, and TestNoPackFixtureLivesInTheSanitisersMintingSpace in
+// internal/cli holds it for every pack.
 var catalogueSnapshots = []map[string]any{
 	{"SnapshotId": "snap-fe1a7001", "VolumeId": "vol-fe1a7001", "VolumeSize": 10, "Description": "Ubuntu-24.04-2025.01 root"},
 	{"SnapshotId": "snap-fe1a7002", "VolumeId": "vol-fe1a7002", "VolumeSize": 10, "Description": "Debian-12-2025.01 root"},
@@ -328,9 +332,9 @@ func catalogueSnapshotOf(i int) map[string]any { return catalogueSnapshots[i] }
 
 var images = func() []map[string]any {
 	out := []map[string]any{
-		{"ImageId": "ami-00000001", "ImageName": "Ubuntu-24.04-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
-		{"ImageId": "ami-00000002", "ImageName": "Debian-12-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
-		{"ImageId": "ami-00000003", "ImageName": "Alpine-3.21-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
+		{"ImageId": "ami-fe1a7001", "ImageName": "Ubuntu-24.04-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
+		{"ImageId": "ami-fe1a7002", "ImageName": "Debian-12-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
+		{"ImageId": "ami-fe1a7003", "ImageName": "Alpine-3.21-2025.01", "Architecture": "x86_64", "State": "available", "RootDeviceType": "bsu", "SecureBoot": false, "AccountId": accountID, "ProductCodes": []any{linuxProductCode}},
 	}
 	// Added here rather than written into each literal: three copies of the
 	// same structure is three places for it to drift, and a fourth image would
@@ -360,9 +364,9 @@ var images = func() []map[string]any {
 // An identifier outside this map resolves to nothing, and the shared binding
 // refuses the boot rather than substituting an OS the client never named (#83).
 var runtimeImages = map[string]machine.Image{
-	"ami-00000001": {Ref: "ubuntu:24.04", User: DefaultUser},
-	"ami-00000002": {Ref: "debian:12", User: DefaultUser},
-	"ami-00000003": {Ref: "alpine:3.21", User: DefaultUser},
+	"ami-fe1a7001": {Ref: "ubuntu:24.04", User: DefaultUser},
+	"ami-fe1a7002": {Ref: "debian:12", User: DefaultUser},
+	"ami-fe1a7003": {Ref: "alpine:3.21", User: DefaultUser},
 }
 
 // accountID is the one account this emulator has. Outscale account IDs are
@@ -560,21 +564,23 @@ func (p *Pack) readSubregions(w http.ResponseWriter, r *http.Request) {
 // real region publishes (measured, X-2 sweep, 2026-08-08:
 // com.outscale.<region>.{api,fcu,lbu,eim,icu,oos,directlink}), templated on the
 // emulated region so a client that builds the name from its own region finds
-// it. The ids are stable so a client can hardcode one, and the ranges are
-// TEST-NET blocks (RFC 5737): a documented-fictional address for a fictional
-// facility, matching what ReadPublicIpRanges publishes.
+// it. The ids are stable so a client can hardcode one, and outside the corpus
+// sanitiser's minting space like every fixture of this file (#395: they were
+// pl-00000001..7, the counter's first seven values); the ranges are TEST-NET
+// blocks (RFC 5737): a documented-fictional address for a fictional facility,
+// matching what ReadPublicIpRanges publishes.
 //
 // Built per pack rather than held in a package variable since #290, because
 // the region the names carry is the pack's datum, not the package's constant.
 func netAccessPointServices(region string) []map[string]any {
 	return []map[string]any{
-		{"ServiceId": "pl-00000001", "ServiceName": "com.outscale." + region + ".api", "IpRanges": []any{"192.0.2.0/24"}},
-		{"ServiceId": "pl-00000002", "ServiceName": "com.outscale." + region + ".fcu", "IpRanges": []any{"192.0.2.0/24"}},
-		{"ServiceId": "pl-00000003", "ServiceName": "com.outscale." + region + ".lbu", "IpRanges": []any{"192.0.2.0/24"}},
-		{"ServiceId": "pl-00000004", "ServiceName": "com.outscale." + region + ".eim", "IpRanges": []any{"192.0.2.0/24"}},
-		{"ServiceId": "pl-00000005", "ServiceName": "com.outscale." + region + ".icu", "IpRanges": []any{"192.0.2.0/24"}},
-		{"ServiceId": "pl-00000006", "ServiceName": "com.outscale." + region + ".oos", "IpRanges": []any{"198.51.100.0/24"}},
-		{"ServiceId": "pl-00000007", "ServiceName": "com.outscale." + region + ".directlink", "IpRanges": []any{"198.51.100.0/24"}},
+		{"ServiceId": "pl-fe1a7001", "ServiceName": "com.outscale." + region + ".api", "IpRanges": []any{"192.0.2.0/24"}},
+		{"ServiceId": "pl-fe1a7002", "ServiceName": "com.outscale." + region + ".fcu", "IpRanges": []any{"192.0.2.0/24"}},
+		{"ServiceId": "pl-fe1a7003", "ServiceName": "com.outscale." + region + ".lbu", "IpRanges": []any{"192.0.2.0/24"}},
+		{"ServiceId": "pl-fe1a7004", "ServiceName": "com.outscale." + region + ".eim", "IpRanges": []any{"192.0.2.0/24"}},
+		{"ServiceId": "pl-fe1a7005", "ServiceName": "com.outscale." + region + ".icu", "IpRanges": []any{"192.0.2.0/24"}},
+		{"ServiceId": "pl-fe1a7006", "ServiceName": "com.outscale." + region + ".oos", "IpRanges": []any{"198.51.100.0/24"}},
+		{"ServiceId": "pl-fe1a7007", "ServiceName": "com.outscale." + region + ".directlink", "IpRanges": []any{"198.51.100.0/24"}},
 	}
 }
 

--- a/internal/providers/outscale/catalog_test.go
+++ b/internal/providers/outscale/catalog_test.go
@@ -125,31 +125,42 @@ var createImageBsuKeys = []string{"SnapshotId", "VolumeSize", "VolumeType", "Del
 //
 // #395 measured what happens otherwise: the sanitiser hands out prefixed
 // identifiers as a shared counter in eight hexadecimal digits, so ami-00000001
-// came out naming a catalogue image of this emulator and two corpus exemptions
-// exist to carry the confusion. #389 added three snapshots and three volume
-// identifiers to this file; numbering them the same way would have widened a
-// known defect for free.
+// came out of a recording naming a catalogue image of this emulator, and two
+// corpus exemptions carried the confusion until the images moved. #389 had
+// already numbered its snapshots and volumes outside the space; the images
+// followed with #395, and this test holds all three tables plus the boot map.
 //
-// The test is on the objects #389 added, not on the pre-existing ami- ones:
-// those are #395's to move, and asserting on them here would make this test
-// fail for somebody else's issue.
+// The cross-pack half, which reads every pack's source rather than one
+// catalogue, is TestNoPackFixtureLivesInTheSanitisersMintingSpace in
+// internal/cli.
 func TestTheCatalogueIdentifiersStayOutOfTheMintingSpace(t *testing.T) {
-	if len(catalogueSnapshots) == 0 {
-		t.Fatal("the catalogue holds no snapshot, so this test measures nothing")
+	if len(catalogueSnapshots) == 0 || len(images) == 0 || len(runtimeImages) == 0 {
+		t.Fatal("the catalogue holds no snapshot, image or boot, so this test measures nothing")
 	}
+	var ids []string
 	for _, snapshot := range catalogueSnapshots {
 		for _, key := range []string{"SnapshotId", "VolumeId"} {
 			id, _ := snapshot[key].(string)
-			_, hex, ok := strings.Cut(id, "-")
-			if !ok {
-				t.Errorf("%s %q carries no prefix", key, id)
-				continue
-			}
-			// The mint counts up from one, so a value the counter can reach in
-			// any plausible recording is one with leading zeros.
-			if strings.HasPrefix(hex, "0000") {
-				t.Errorf("%s %q sits in the sanitiser's minting space, which is #395", key, id)
-			}
+			ids = append(ids, key+" "+id)
+		}
+	}
+	for _, image := range images {
+		id, _ := image["ImageId"].(string)
+		ids = append(ids, "ImageId "+id)
+	}
+	for id := range runtimeImages {
+		ids = append(ids, "boot "+id)
+	}
+	for _, entry := range ids {
+		_, hex, ok := strings.Cut(entry[strings.LastIndex(entry, " ")+1:], "-")
+		if !ok {
+			t.Errorf("%s carries no prefix", entry)
+			continue
+		}
+		// The mint counts up from one, so a value the counter can reach in
+		// any plausible recording is one with leading zeros.
+		if strings.HasPrefix(hex, "0000") {
+			t.Errorf("%s sits in the sanitiser's minting space, which is #395", entry)
 		}
 	}
 }

--- a/internal/providers/outscale/contract_test.go
+++ b/internal/providers/outscale/contract_test.go
@@ -99,7 +99,7 @@ func TestEveryResponseMatchesTheContract(t *testing.T) {
 		`{"KeypairName":"conformance","PublicKey":"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD conformance@feint"}`)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","KeypairName":"conformance"}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","KeypairName":"conformance"}`)
 	id := firstVMID(t, created)
 
 	call(t, ts, doc, "ReadVms", `{"Filters":{"VmIds":["`+id+`"]}}`)

--- a/internal/providers/outscale/firewall_internal_test.go
+++ b/internal/providers/outscale/firewall_internal_test.go
@@ -97,7 +97,7 @@ func storedVM(p *Pack, groupIDs ...string) *resource.Resource {
 	now := p.env.Now()
 	res := resource.New(newVMID(p.env.NewID()), kindVM, resource.Tenant{Provider: Name}, stateStopped, now)
 	res.Attrs = map[string]any{
-		"ImageId":          "ami-00000001",
+		"ImageId":          "ami-fe1a7001",
 		"VmType":           defaultVMType,
 		"SecurityGroupIds": groupIDs,
 	}

--- a/internal/providers/outscale/flexiblegpu_test.go
+++ b/internal/providers/outscale/flexiblegpu_test.go
@@ -118,7 +118,7 @@ func TestLinkingAnFGpuTwiceIsRefused(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.95.0.0/16", "10.95.1.0/24")
 	newVM := func() string {
 		status, made := post(t, ts, "CreateVms",
-			`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+			`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 		if status != http.StatusOK {
 			t.Fatalf("CreateVms: %d (%v)", status, made)
 		}

--- a/internal/providers/outscale/loadbalancer_dataplane_test.go
+++ b/internal/providers/outscale/loadbalancer_dataplane_test.go
@@ -87,7 +87,7 @@ func aBalancedStack(t *testing.T, ts *httptest.Server) (vmA, vmB, vip string) {
 	launch := func() string {
 		t.Helper()
 		out := call(t, ts, contractDoc, "CreateVms",
-			`{"ImageId":"ami-00000003","VmType":"tinav6.c1r1p2","SubnetId":"`+subnet+`"}`)
+			`{"ImageId":"ami-fe1a7003","VmType":"tinav6.c1r1p2","SubnetId":"`+subnet+`"}`)
 		vms, _ := out["Vms"].([]any)
 		if len(vms) == 0 {
 			t.Fatalf("CreateVms answered no machine: %v", out)
@@ -416,7 +416,7 @@ func TestAPartialDeliveryIsRecordedAndSaidAtWarn(t *testing.T) {
 	launch := func() (id, ip string) {
 		t.Helper()
 		out := call(t, ts, doc, "CreateVms",
-			`{"ImageId":"ami-00000003","VmType":"tinav6.c1r1p2","SubnetId":"`+subnet+`"}`)
+			`{"ImageId":"ami-fe1a7003","VmType":"tinav6.c1r1p2","SubnetId":"`+subnet+`"}`)
 		vms, _ := out["Vms"].([]any)
 		if len(vms) == 0 {
 			t.Fatalf("CreateVms answered no machine: %v", out)

--- a/internal/providers/outscale/loadbalancers_test.go
+++ b/internal/providers/outscale/loadbalancers_test.go
@@ -135,7 +135,7 @@ func TestBackendVmsRegisterAndUnlink(t *testing.T) {
 	sgID := aSecurityGroup(t, ts, netID, "sg_lb")
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","SubnetId":"`+subnetID+`"}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1","SubnetId":"`+subnetID+`"}`)
 	vms, _ := created["Vms"].([]any)
 	vmID, _ := vms[0].(map[string]any)["VmId"].(string)
 

--- a/internal/providers/outscale/machines_internal_test.go
+++ b/internal/providers/outscale/machines_internal_test.go
@@ -52,9 +52,9 @@ func runtimePack(driver machine.Runtime) *Pack {
 // identifier outside the table resolves to nothing at all.
 func TestOutscaleImageResolutionIsExact(t *testing.T) {
 	rows := map[string]machine.Image{
-		"ami-00000001": {Ref: "ubuntu:24.04", User: "outscale"},
-		"ami-00000002": {Ref: "debian:12", User: "outscale"},
-		"ami-00000003": {Ref: "alpine:3.21", User: "outscale"},
+		"ami-fe1a7001": {Ref: "ubuntu:24.04", User: "outscale"},
+		"ami-fe1a7002": {Ref: "debian:12", User: "outscale"},
+		"ami-fe1a7003": {Ref: "alpine:3.21", User: "outscale"},
 	}
 	if len(rows) != len(runtimeImages) {
 		t.Fatalf("the table serves %d OMIs and this test knows %d: add the row here, one per OMI", len(runtimeImages), len(rows))
@@ -143,7 +143,7 @@ func TestAServedOmiBootsWithItsLogin(t *testing.T) {
 	res := &resource.Resource{
 		ID:    "i-00000001",
 		State: stateStopped,
-		Attrs: map[string]any{"ImageId": "ami-00000002"},
+		Attrs: map[string]any{"ImageId": "ami-fe1a7002"},
 	}
 
 	p.powerOn(context.Background(), res)

--- a/internal/providers/outscale/netdefaults_test.go
+++ b/internal/providers/outscale/netdefaults_test.go
@@ -153,7 +153,7 @@ func TestAVmInANetHasANic(t *testing.T) {
 
 	netID, subnetID := netAndSubnet(t, ts, "10.9.0.0/16", "10.9.1.0/24")
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := created["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/outscale/netresources_test.go
+++ b/internal/providers/outscale/netresources_test.go
@@ -232,7 +232,7 @@ func TestTheNetCataloguesAreFixedAndFilterable(t *testing.T) {
 	}
 	one := firstOf(t, call(t, ts, doc, "ReadNetAccessPointServices",
 		`{"Filters":{"ServiceNames":["com.outscale.eu-west-2.api"]}}`), "Services")
-	if one["ServiceId"] != "pl-00000001" {
+	if one["ServiceId"] != "pl-fe1a7001" {
 		t.Fatalf("the api service is not the fixed one: %v", one)
 	}
 }

--- a/internal/providers/outscale/nics_lifecycle_test.go
+++ b/internal/providers/outscale/nics_lifecycle_test.go
@@ -33,7 +33,7 @@ func TestANicLifecycleMatchesTheRecordedShapes(t *testing.T) {
 
 	// A machine in the same Subnet, to attach it to.
 	vmCreated := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vm, _ := vmCreated["Vms"].([]any)[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
 
@@ -114,7 +114,7 @@ func TestDeletingAVmDetachesItsSecondaryNics(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.41.0.0/16", "10.41.1.0/24")
 	nicID, _ := call(t, ts, doc, "CreateNic", `{"SubnetId":"`+subnetID+`"}`)["Nic"].(map[string]any)["NicId"].(string)
 	vm, _ := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)["Vms"].([]any)[0].(map[string]any)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SubnetId":"`+subnetID+`","BootOnCreation":false}`)["Vms"].([]any)[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)
 	call(t, ts, doc, "LinkNic", `{"NicId":"`+nicID+`","VmId":"`+vmID+`","DeviceNumber":1}`)
 
@@ -147,7 +147,7 @@ func TestAnAttachedNicReportsTheLinkStateTheProviderWaitsFor(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.81.0.0/16", "10.81.1.0/24")
 
 	_, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/outscale/order_test.go
+++ b/internal/providers/outscale/order_test.go
@@ -77,7 +77,7 @@ func TestAMachinesSecurityGroupsAnswerInIdentifierOrder(t *testing.T) {
 	asked := []string{want[1], want[0]}
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false,`+
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false,`+
 			`"SecurityGroupIds":["`+asked[0]+`","`+asked[1]+`"]}`)
 	vms, _ := created["Vms"].([]any)
 	if len(vms) != 1 {
@@ -172,7 +172,7 @@ func TestAMachineAnswersUserDataAndTagsEvenWithNeither(t *testing.T) {
 
 	_, subnetID := netAndSubnet(t, ts, "10.63.0.0/16", "10.63.1.0/24")
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	vms, _ := created["Vms"].([]any)
 	if len(vms) != 1 {
 		t.Fatalf("no machine was created: %v", created)

--- a/internal/providers/outscale/placement_test.go
+++ b/internal/providers/outscale/placement_test.go
@@ -33,7 +33,7 @@ func TestATerminatedVmsAddressReturnsToItsSubnet(t *testing.T) {
 
 	create := func() (int, string, string) {
 		status, out := postRaw(ts, "CreateVms",
-			fmt.Sprintf(`{"ImageId":"ami-00000001","SubnetId":%q,"BootOnCreation":false}`, subnetID))
+			fmt.Sprintf(`{"ImageId":"ami-fe1a7001","SubnetId":%q,"BootOnCreation":false}`, subnetID))
 		vms, _ := out["Vms"].([]any)
 		if len(vms) == 0 {
 			return status, "", ""

--- a/internal/providers/outscale/privateips_lock_test.go
+++ b/internal/providers/outscale/privateips_lock_test.go
@@ -121,7 +121,7 @@ func TestAnAddressLinkDoesNotHoldTheAddressLockAcrossTheRuntime(t *testing.T) {
 	// and this test would measure the absence of the call again — under the
 	// old derived name it silently reconfigured a machine the Vm never started.
 	status, doc := doAction(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav4.c1r1p2","SubnetId":"`+subnet+`"}`)
 	if status != http.StatusOK {
 		t.Fatalf("CreateVms answered %d: %v", status, doc)
 	}

--- a/internal/providers/outscale/privateips_test.go
+++ b/internal/providers/outscale/privateips_test.go
@@ -143,7 +143,7 @@ func TestALinkedAddressIsNotHandedToTheNextVm(t *testing.T) {
 	// Every Vm the Subnet can still hold, and none of them may take one.
 	for range 5 {
 		status, doc := doAction(t, ts, "CreateVms",
-			`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SubnetId":"`+sub+`"}`)
+			`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SubnetId":"`+sub+`"}`)
 		if status != http.StatusOK {
 			break
 		}

--- a/internal/providers/outscale/publicip_routing_test.go
+++ b/internal/providers/outscale/publicip_routing_test.go
@@ -143,7 +143,7 @@ func aLinkedVm(t *testing.T, ts *httptest.Server) (vmID, ipID, address string) {
 	if address == "" {
 		t.Fatal("no address allocated")
 	}
-	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
+	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ = vm["VmId"].(string)
@@ -213,7 +213,7 @@ func TestAPoisonedPublicIpIsNeverRouted(t *testing.T) {
 	stored.Attrs["PublicIp"] = poison
 	env.Store.Commit(base, stored, env.Now())
 
-	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
+	_, out = post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2"}`)
 	vms, _ := out["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	vmID, _ := vm["VmId"].(string)

--- a/internal/providers/outscale/regions_test.go
+++ b/internal/providers/outscale/regions_test.go
@@ -109,7 +109,7 @@ func TestANonDefaultRegionAgreesWithItself(t *testing.T) {
 	}
 
 	vm := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","BootOnCreation":false,`+
+		`{"ImageId":"ami-fe1a7001","BootOnCreation":false,`+
 			`"Placement":{"SubregionName":"cloudgouv-eu-west-1c"}}`)
 	assertPlacement(t, vm, "cloudgouv-eu-west-1c", "default", "a Vm placed in the region's third zone")
 	id := firstVMID(t, vm)
@@ -118,7 +118,7 @@ func TestANonDefaultRegionAgreesWithItself(t *testing.T) {
 
 	// A Vm with nothing said lands in the region's own first zone, never in
 	// the default region's.
-	silent := call(t, ts, doc, "CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false}`)
+	silent := call(t, ts, doc, "CreateVms", `{"ImageId":"ami-fe1a7001","BootOnCreation":false}`)
 	assertPlacement(t, silent, "cloudgouv-eu-west-1a", "default", "a Vm with no Placement")
 
 	// And the default region's zones are refused here, by every door: this
@@ -127,7 +127,7 @@ func TestANonDefaultRegionAgreesWithItself(t *testing.T) {
 	for _, probe := range []struct{ action, body string }{
 		{"CreateSubnet", `{"NetId":"` + netID + `","IpRange":"10.66.2.0/24","SubregionName":"eu-west-2a"}`},
 		{"CreateVolume", `{"SubregionName":"eu-west-2a","Size":7}`},
-		{"CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false,"Placement":{"SubregionName":"eu-west-2a"}}`},
+		{"CreateVms", `{"ImageId":"ami-fe1a7001","BootOnCreation":false,"Placement":{"SubregionName":"eu-west-2a"}}`},
 	} {
 		status, refused := post(t, ts, probe.action, probe.body)
 		if status != http.StatusBadRequest {

--- a/internal/providers/outscale/rootvolume_test.go
+++ b/internal/providers/outscale/rootvolume_test.go
@@ -381,7 +381,7 @@ func TestAnUnknownImageStillYieldsARootVolume(t *testing.T) {
 	// entry rather than to nothing. A falsification proved the earlier version
 	// of this test blind to that — it only asked whether some volume existed,
 	// so resolving the image to nothing at all left it green.
-	_, catalogue := post(t, ts, "ReadImages", `{"Filters":{"ImageIds":["ami-00000001"]}}`)
+	_, catalogue := post(t, ts, "ReadImages", `{"Filters":{"ImageIds":["ami-fe1a7001"]}}`)
 	def, _ := catalogue["Images"].([]any)[0].(map[string]any)
 	defMappings, _ := def["BlockDeviceMappings"].([]any)
 	defMapping, _ := defMappings[0].(map[string]any)
@@ -494,7 +494,7 @@ func TestAFailedBatchLeavesNoRootVolume(t *testing.T) {
 	// Two of the three addresses taken, so the batch below can place one more
 	// machine and no second.
 	if status, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","MaxVmsCount":2,"SubnetId":"`+subnetID+`"}`); status != http.StatusOK {
+		`{"ImageId":"ami-fe1a7001","MaxVmsCount":2,"SubnetId":"`+subnetID+`"}`); status != http.StatusOK {
 		t.Fatalf("the setup create answered %d: %v", status, out)
 	}
 
@@ -502,7 +502,7 @@ func TestAFailedBatchLeavesNoRootVolume(t *testing.T) {
 	was := readIDs(before, "Volumes", "VolumeId")
 
 	status, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","MaxVmsCount":3,"SubnetId":"`+subnetID+`"}`)
+		`{"ImageId":"ami-fe1a7001","MaxVmsCount":3,"SubnetId":"`+subnetID+`"}`)
 	if status == http.StatusOK {
 		t.Fatalf("CreateVms placed three machines in a subnet holding one free address: %v", out)
 	}
@@ -538,7 +538,7 @@ func TestAMachineFromAnImageWithNoMappingGetsAnUnsourcedRootVolume(t *testing.T)
 
 	// A machine to cut the image from, which is the only way to reach an image
 	// with no device mapping.
-	_, madeVM := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001"}`)
+	_, madeVM := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001"}`)
 	sourceVM, _ := madeVM["Vms"].([]any)[0].(map[string]any)
 	sourceID, _ := sourceVM["VmId"].(string)
 

--- a/internal/providers/outscale/securitygroups_lifecycle_test.go
+++ b/internal/providers/outscale/securitygroups_lifecycle_test.go
@@ -79,7 +79,7 @@ func TestASecurityGroupLifecycleMatchesTheRecordedShapes(t *testing.T) {
 	// A machine wears the group it asked for, and the view resolves the pair.
 	_, _ = post(t, ts, "CreateSubnet", `{"NetId":"`+netID+`","IpRange":"10.20.1.0/24"}`)
 	vmCreated := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["`+sgID+`"]}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["`+sgID+`"]}`)
 	vms, _ := vmCreated["Vms"].([]any)
 	vm, _ := vms[0].(map[string]any)
 	worn, _ := vm["SecurityGroups"].([]any)
@@ -106,7 +106,7 @@ func TestASecurityGroupLifecycleMatchesTheRecordedShapes(t *testing.T) {
 
 	// An unknown group on a create is a refusal, not a machine without rules.
 	if status, body := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["sg-00000000"]}`); status == http.StatusOK {
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["sg-00000000"]}`); status == http.StatusOK {
 		t.Fatalf("an unknown security group was accepted on a create: %v", body)
 	}
 

--- a/internal/providers/outscale/stateconflict_test.go
+++ b/internal/providers/outscale/stateconflict_test.go
@@ -29,7 +29,7 @@ func conflictCode(body map[string]any) string {
 func TestStartVmsRefusesAMachineAlreadyRunning(t *testing.T) {
 	ts := newServer(t)
 
-	status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2"}`)
+	status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav4.c1r1p2"}`)
 	if status != http.StatusOK {
 		t.Fatalf("CreateVms: %d (%v)", status, created)
 	}
@@ -94,7 +94,7 @@ func TestLinkVolumeStillRefusesAVolumeHeldElsewhere(t *testing.T) {
 	ts := newServer(t)
 
 	newVM := func() string {
-		status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav4.c1r1p2"}`)
+		status, created := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav4.c1r1p2"}`)
 		if status != http.StatusOK {
 			t.Fatalf("CreateVms: %d (%v)", status, created)
 		}

--- a/internal/providers/outscale/strict_test.go
+++ b/internal/providers/outscale/strict_test.go
@@ -31,29 +31,29 @@ func strictServer(t *testing.T, declaration string) *httptest.Server {
 }
 
 func TestAStrictCatalogueRefusesAnUndeclaredImageAndType(t *testing.T) {
-	ts := strictServer(t, `{"outscale": {"images": ["ami-00000001"], "types": ["tinav6.c1r1p2"]}}`)
+	ts := strictServer(t, `{"outscale": {"images": ["ami-fe1a7001"], "types": ["tinav6.c1r1p2"]}}`)
 
 	// The typo: 400, code 5023, InvalidResource, the recorded refusal of an
 	// image that does not exist.
-	status, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000002","VmType":"tinav6.c1r1p2"}`)
+	status, out := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7002","VmType":"tinav6.c1r1p2"}`)
 	if status != http.StatusBadRequest {
 		t.Fatalf("an undeclared image answered %d: %v", status, out)
 	}
 	errs, _ := out["Errors"].([]any)
 	first, _ := errs[0].(map[string]any)
-	if first["Code"] != "5023" || first["Type"] != "InvalidResource" || !strings.Contains(first["Details"].(string), "ami-00000002") {
+	if first["Code"] != "5023" || first["Type"] != "InvalidResource" || !strings.Contains(first["Details"].(string), "ami-fe1a7002") {
 		t.Errorf("the refusal is not the recorded one: %v", first)
 	}
 
 	// A type outside the declaration.
-	status, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c2r4p2"}`)
+	status, out = post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav6.c2r4p2"}`)
 	if status != http.StatusBadRequest {
 		t.Fatalf("an undeclared type answered %d: %v", status, out)
 	}
 
 	// The accepting half, or a guard refusing every create would pass the two
 	// above: the declared pair creates a machine.
-	status, out = post(t, ts, "CreateVms", `{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2"}`)
+	status, out = post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2"}`)
 	if status != http.StatusOK {
 		t.Fatalf("the declared image and type answered %d: %v", status, out)
 	}
@@ -75,7 +75,7 @@ func TestAStrictCatalogueRefusesAnUndeclaredImageAndType(t *testing.T) {
 	_, images := post(t, ts, "ReadImages", `{}`)
 	for _, entry := range images["Images"].([]any) {
 		id, _ := entry.(map[string]any)["ImageId"].(string)
-		if id == "ami-00000002" || id == "ami-00000003" {
+		if id == "ami-fe1a7002" || id == "ami-fe1a7003" {
 			t.Errorf("ReadImages lists %s, outside the declaration", id)
 		}
 	}
@@ -90,7 +90,7 @@ func TestAStrictCatalogueRefusesAnUndeclaredImageAndType(t *testing.T) {
 // machine here, which is #392's standing decision.
 func TestNoDeclarationChangesNothing(t *testing.T) {
 	ts := newServer(t)
-	if status, out := post(t, ts, "CreateVms", `{"ImageId":"ami-00000002","VmType":"tinav6.c2r4p2"}`); status != http.StatusOK {
+	if status, out := post(t, ts, "CreateVms", `{"ImageId":"ami-fe1a7002","VmType":"tinav6.c2r4p2"}`); status != http.StatusOK {
 		t.Fatalf("without a declaration a create was refused: %d %v", status, out)
 	}
 	if status, out := post(t, ts, "CreateVms", `{"ImageId":"ami-99999999","VmType":"tinav6.c1r1p2"}`); status != http.StatusOK {

--- a/internal/providers/outscale/subregions_test.go
+++ b/internal/providers/outscale/subregions_test.go
@@ -51,7 +51,7 @@ func TestAVmCreatedInANamedSubregionReadsBackInIt(t *testing.T) {
 	doc := contractDoc(t)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","BootOnCreation":false,`+
+		`{"ImageId":"ami-fe1a7001","BootOnCreation":false,`+
 			`"Placement":{"SubregionName":"eu-west-2b","Tenancy":"dedicated"}}`)
 	assertPlacement(t, created, "eu-west-2b", "dedicated", "the create's own answer")
 	id := firstVMID(t, created)
@@ -109,7 +109,7 @@ func TestAVmInheritsItsSubnetsSubregion(t *testing.T) {
 	}
 
 	vm := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	assertPlacement(t, vm, "eu-west-2b", "default", "a Vm placed by its Subnet alone")
 
 	// The Subnet answers the zone filter from the stored fact.
@@ -132,7 +132,7 @@ func TestAVmWithoutAPlacementReadsBackTheDefault(t *testing.T) {
 	ts := newServer(t)
 	doc := contractDoc(t)
 
-	created := call(t, ts, doc, "CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false}`)
+	created := call(t, ts, doc, "CreateVms", `{"ImageId":"ami-fe1a7001","BootOnCreation":false}`)
 	assertPlacement(t, created, "eu-west-2a", "default", "a Vm with no Placement")
 }
 
@@ -210,7 +210,7 @@ func TestWhatACreateAcceptsTheCatalogueDeclares(t *testing.T) {
 	for _, probe := range []struct{ action, body string }{
 		{"CreateSubnet", `{"NetId":"` + netID + `","IpRange":"10.64.9.0/24","SubregionName":"cloudgouv-eu-west-1a"}`},
 		{"CreateVolume", `{"SubregionName":"cloudgouv-eu-west-1a","Size":10}`},
-		{"CreateVms", `{"ImageId":"ami-00000001","BootOnCreation":false,"Placement":{"SubregionName":"cloudgouv-eu-west-1a"}}`},
+		{"CreateVms", `{"ImageId":"ami-fe1a7001","BootOnCreation":false,"Placement":{"SubregionName":"cloudgouv-eu-west-1a"}}`},
 	} {
 		status, refused := post(t, ts, probe.action, probe.body)
 		if status != http.StatusBadRequest {
@@ -228,7 +228,7 @@ func TestAPlacementContradictingTheSubnetIsRefused(t *testing.T) {
 	_, subnetID := netAndSubnet(t, ts, "10.65.0.0/16", "10.65.1.0/24") // default zone
 
 	status, out := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false,`+
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false,`+
 			`"Placement":{"SubregionName":"eu-west-2b"}}`)
 	if status != http.StatusBadRequest {
 		t.Fatalf("a Placement contradicting the Subnet answered %d: %v", status, out)

--- a/internal/providers/outscale/tagfilters_test.go
+++ b/internal/providers/outscale/tagfilters_test.go
@@ -121,7 +121,7 @@ func TestTagFiltersReachEveryReadTheRecordingExercised(t *testing.T) {
 
 	_, subnetID := netAndSubnet(t, ts, "10.92.0.0/16", "10.92.1.0/24")
 	status, vm := post(t, ts, "CreateVms",
-		`{"ImageId":"ami-00000001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","SubnetId":"`+subnetID+`","BootOnCreation":false}`)
 	if status != http.StatusOK {
 		t.Fatalf("CreateVms: %d (%v)", status, vm)
 	}

--- a/internal/providers/outscale/vmoptions_test.go
+++ b/internal/providers/outscale/vmoptions_test.go
@@ -50,7 +50,7 @@ func TestAVmReadsBackItsOwnOptions(t *testing.T) {
 	doc := contractDoc(t)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false,`+
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1","BootOnCreation":false,`+
 			`"BootMode":"legacy","Performance":"medium","VmInitiatedShutdownBehavior":"restart",`+
 			`"TpmEnabled":true,`+
 			`"ShutdownBehaviorConfiguration":{"GuestAction":"terminate","HostAction":"stop"},`+
@@ -87,7 +87,7 @@ func TestAVmCreatedWithDefaultsReadsThePlatformOnes(t *testing.T) {
 	doc := contractDoc(t)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1","BootOnCreation":false}`)
 	vm := vmOf(t, created)
 	assertVmOptions(t, vm, map[string]any{
 		"BootMode":                    "uefi",
@@ -115,7 +115,7 @@ func TestTheVmTypePerformanceFlagWins(t *testing.T) {
 	doc := contractDoc(t)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p3","BootOnCreation":false,"Performance":"highest"}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p3","BootOnCreation":false,"Performance":"highest"}`)
 	assertVmOptions(t, vmOf(t, created), map[string]any{"Performance": "medium"},
 		"a p3 type beside Performance=highest")
 }
@@ -129,7 +129,7 @@ func TestUpdateVmMovesTheOptions(t *testing.T) {
 	doc := contractDoc(t)
 
 	created := call(t, ts, doc, "CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1","BootOnCreation":false,"Performance":"medium"}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1","BootOnCreation":false,"Performance":"medium"}`)
 	id := firstVMID(t, created)
 
 	updated := call(t, ts, doc, "UpdateVm",
@@ -168,11 +168,11 @@ func TestVmOptionsOutsideTheirEnumAreRefused(t *testing.T) {
 		label string
 		body  string
 	}{
-		{"BootMode", `{"ImageId":"ami-00000001","BootMode":"bios"}`},
-		{"Performance", `{"ImageId":"ami-00000001","Performance":"turbo"}`},
-		{"VmInitiatedShutdownBehavior", `{"ImageId":"ami-00000001","VmInitiatedShutdownBehavior":"hibernate"}`},
-		{"GuestAction", `{"ImageId":"ami-00000001","ShutdownBehaviorConfiguration":{"GuestAction":"restart"}}`},
-		{"SecureBoot", `{"ImageId":"ami-00000001","ActionsOnNextBoot":{"SecureBoot":"maybe"}}`},
+		{"BootMode", `{"ImageId":"ami-fe1a7001","BootMode":"bios"}`},
+		{"Performance", `{"ImageId":"ami-fe1a7001","Performance":"turbo"}`},
+		{"VmInitiatedShutdownBehavior", `{"ImageId":"ami-fe1a7001","VmInitiatedShutdownBehavior":"hibernate"}`},
+		{"GuestAction", `{"ImageId":"ami-fe1a7001","ShutdownBehaviorConfiguration":{"GuestAction":"restart"}}`},
+		{"SecureBoot", `{"ImageId":"ami-fe1a7001","ActionsOnNextBoot":{"SecureBoot":"maybe"}}`},
 	}
 	for _, tc := range cases {
 		status, out := post(t, ts, "CreateVms", tc.body)

--- a/internal/providers/replay_test.go
+++ b/internal/providers/replay_test.go
@@ -343,7 +343,7 @@ func outscaleLinked(t *testing.T) (*machine.Recorder, http.Handler, string) {
 	ipID := id(t, ip, "PublicIp", "PublicIpId")
 
 	vms := post("CreateVms",
-		`{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["`+sgID+`"]}`)
+		`{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","SecurityGroupIds":["`+sgID+`"]}`)
 	list, _ := vms["Vms"].([]any)
 	if len(list) != 1 {
 		t.Fatalf("CreateVms answered %d Vms, want 1: %v", len(list), vms)

--- a/tools/conformance/outscale/balancer.sh
+++ b/tools/conformance/outscale/balancer.sh
@@ -125,7 +125,7 @@ sub_id="$(osc CreateSubnet --NetId "$net_id" --IpRange "$SUBBLOCK" | jq -r '.Sub
 
 launch() {
   local doc
-  doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$sub_id")" \
+  doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$sub_id")" \
     || { echo "CreateVms rejected: $doc" >&2; return 1; }
   printf '%s' "$doc" | jq -r '.Vms[0].VmId + " " + .Vms[0].PrivateIp'
 }

--- a/tools/conformance/outscale/network.sh
+++ b/tools/conformance/outscale/network.sh
@@ -182,7 +182,7 @@ ok "the mask on the host is the mask the client asked for"
 # A Subnet nothing can be placed on is a demo. The pack declared SubnetId on
 # CreateVms and read nothing, so a client got a 200 and a Vm that was nowhere.
 echo "- a Vm placed on the Subnet carries the address the API published"
-vm="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --SubnetId "$sub_id")" \
+vm="$(osc CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c1r1p2 --SubnetId "$sub_id")" \
   || fail "CreateVms rejected a SubnetId: $vm"
 vm_id="$(printf '%s' "$vm" | jq -r '.Vms[0].VmId')"
 private_ip="$(printf '%s' "$vm" | jq -r '.Vms[0].PrivateIp // empty')"
@@ -268,9 +268,9 @@ sub_a="$(osc CreateSubnet --NetId "$net_a" --IpRange "${PEER_BLOCK_A%.0.0/16}.1.
 sub_b="$(osc CreateSubnet --NetId "$net_b" --IpRange "${PEER_BLOCK_B%.0.0/16}.1.0/24" | jq -r '.Subnet.SubnetId')"
 [ -n "$sub_a" ] && [ -n "$sub_b" ] || fail "the two Subnets were not created"
 
-vm_a_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$sub_a")" \
+vm_a_doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$sub_a")" \
   || fail "CreateVms rejected in $sub_a: $vm_a_doc"
-vm_b_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$sub_b")" \
+vm_b_doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$sub_b")" \
   || fail "CreateVms rejected in $sub_b: $vm_b_doc"
 vm_a="$(printf '%s' "$vm_a_doc" | jq -r '.Vms[0].VmId')"
 vm_b="$(printf '%s' "$vm_b_doc" | jq -r '.Vms[0].VmId')"
@@ -366,7 +366,7 @@ wait_until 30 reach \
 ok "the existing machine still reaches $ip_b after the create"
 
 echo "- a machine born in that Subnet joins the active peering (#508)"
-born_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$born_sub")" \
+born_doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$born_sub")" \
   || fail "CreateVms rejected in $born_sub: $born_doc"
 born_vm="$(printf '%s' "$born_doc" | jq -r '.Vms[0].VmId')"
 born_ip="$(printf '%s' "$born_doc" | jq -r '.Vms[0].PrivateIp // empty')"
@@ -410,7 +410,7 @@ same_sub="$(osc CreateSubnet --NetId "$net_a" --IpRange "${PEER_BLOCK_A%.0.0/16}
 if [ -z "$same_sub" ]; then
   skip "a second Subnet of the same Net was refused; the accepting half is not measured"
 else
-  same_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$same_sub")"
+  same_doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$same_sub")"
   same_vm="$(printf '%s' "$same_doc" | jq -r '.Vms[0].VmId')"
   same_ip="$(printf '%s' "$same_doc" | jq -r '.Vms[0].PrivateIp // empty')"
   wait_until 60 machine_carries "feint-osc-$same_vm" "$same_ip" || true

--- a/tools/conformance/outscale/ssh.sh
+++ b/tools/conformance/outscale/ssh.sh
@@ -117,7 +117,7 @@ public="$(printf '%s' "$created_ip" | jq -r '.PublicIp.PublicIp // empty')"
 ok "$public ($ip_id)"
 
 echo "- boot a Vm carrying the keypair"
-vm="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --KeypairName "$KEY_NAME")" \
+vm="$(osc CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c1r1p2 --KeypairName "$KEY_NAME")" \
   || fail "CreateVms rejected: $vm"
 vm_id="$(printf '%s' "$vm" | jq -r '.Vms[0].VmId // empty')"
 [ -n "$vm_id" ] || fail "no VmId in the create response: $vm"

--- a/tools/conformance/outscale/terraform.sh
+++ b/tools/conformance/outscale/terraform.sh
@@ -395,7 +395,7 @@ printf '%s' "$image_list" | jq -e --arg s "$snapshot_id" \
 # And the catalogue is still there beside it.
 all_images="$(curl -sf -X POST "$ENDPOINT/api/v1/ReadImages" -H 'Content-Type: application/json' -d '{}')" \
   || fail "ReadImages rejected"
-printf '%s' "$all_images" | jq -e '[.Images[] | select(.ImageId == "ami-00000001")] | length == 1' >/dev/null \
+printf '%s' "$all_images" | jq -e '[.Images[] | select(.ImageId == "ami-fe1a7001")] | length == 1' >/dev/null \
   || fail "the fixed catalogue vanished once an image was registered: $all_images"
 ok "volume linked, snapshot completed, image cut from it and listed"
 

--- a/tools/conformance/outscale/terraform/main.tf
+++ b/tools/conformance/outscale/terraform/main.tf
@@ -132,14 +132,14 @@ resource "outscale_volume" "conformance" {
 }
 
 resource "outscale_vm" "conformance" {
-  # A catalogue OMI, and it matters beyond realism: ami-00000003 is one of the
+  # A catalogue OMI, and it matters beyond realism: ami-fe1a7003 is one of the
   # three identifiers the emulator can actually boot (catalog.go maps it to a
   # machine image). The previous ami-12345678 resolved to nothing, which a
   # --vm off run never notices — and under a runtime the boot is then refused
   # (#83, no substitution), the Vm honestly never reaches "running", and the
   # empty-plan assertion fails. Measured on the first full client run under
   # FEINT_VM=incus, which #123's evidence regeneration was the first to do.
-  image_id     = "ami-00000003"
+  image_id     = "ami-fe1a7003"
   vm_type      = "tinav6.c1r1p2"
   subnet_id    = outscale_subnet.conformance.subnet_id
   keypair_name = outscale_keypair.conformance.keypair_name

--- a/tools/conformance/outscale/terraform/multi_az.tf
+++ b/tools/conformance/outscale/terraform/multi_az.tf
@@ -30,7 +30,7 @@ resource "outscale_subnet" "azb" {
 }
 
 resource "outscale_vm" "azb" {
-  image_id  = "ami-00000003"
+  image_id  = "ami-fe1a7003"
   vm_type   = "tinav6.c1r1p2"
   subnet_id = outscale_subnet.azb.subnet_id
 

--- a/tools/conformance/outscale/terraform/vm_options.tf
+++ b/tools/conformance/outscale/terraform/vm_options.tf
@@ -14,7 +14,7 @@
 # The suite's own "second plan is empty" gate is what bites if any of the
 # three reads back a constant again.
 resource "outscale_vm" "options" {
-  image_id = "ami-00000002"
+  image_id = "ami-fe1a7002"
   vm_type  = "tinav6.c1r1"
 
   boot_mode                      = "legacy"

--- a/tools/conformance/parity.sh
+++ b/tools/conformance/parity.sh
@@ -204,7 +204,7 @@ if [ -n "$HAVE_OSC" ]; then
 EOF
   osc_net="$(osc CreateNet --IpRange "$OSC_BLOCK" | jq -r '.Net.NetId')"
   osc_sub="$(osc CreateSubnet --NetId "$osc_net" --IpRange "$OSC_SUBBLOCK" | jq -r '.Subnet.SubnetId')"
-  osc_doc="$(osc CreateVms --ImageId ami-00000003 --VmType tinav6.c1r1p2 --SubnetId "$osc_sub")"
+  osc_doc="$(osc CreateVms --ImageId ami-fe1a7003 --VmType tinav6.c1r1p2 --SubnetId "$osc_sub")"
   osc_vm="$(printf '%s' "$osc_doc" | jq -r '.Vms[0].VmId')"
   osc_priv="$(printf '%s' "$osc_doc" | jq -r '.Vms[0].PrivateIp // empty')"
   [ -n "$osc_vm" ] && [ -n "$osc_priv" ] || fail "the outscale Vm was not created with a PrivateIp"

--- a/tools/conformance/strict-catalog.json
+++ b/tools/conformance/strict-catalog.json
@@ -1,5 +1,5 @@
 {
   "scaleway": {"images": ["debian_bookworm"], "types": ["DEV1-S"]},
-  "outscale": {"images": ["ami-00000001"], "types": ["tinav6.c1r1p2"]},
+  "outscale": {"images": ["ami-fe1a7001"], "types": ["tinav6.c1r1p2"]},
   "exoscale": {"templates": ["11111111-1111-4111-8111-111111111111"], "types": ["21624abb-764e-4def-81d7-9fc54b5957fb"]}
 }

--- a/tools/conformance/strict.sh
+++ b/tools/conformance/strict.sh
@@ -113,12 +113,12 @@ osc() { octl --config "$WORK/config.json" --no-upgrade -o raw iaas api "$@" </de
 
 echo "- octl: an ImageId that names nothing is the recorded 400, code 5023"
 refused "octl on an undeclared image" "5023" osc CreateVms --ImageId ami-1234567a --VmType tinav6.c1r1p2
-refused "octl on an undeclared type" "declared catalogue" osc CreateVms --ImageId ami-00000001 --VmType tinav6.c2r4p2
+refused "octl on an undeclared type" "declared catalogue" osc CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c2r4p2
 ok "refused with the recorded code on the image, and on the type"
 
 echo "- octl: the catalogue a client reads is the one the create accepts"
 images="$(osc ReadImages)" || fail "ReadImages rejected: $images"
-printf '%s' "$images" | jq -e '[.Images[].ImageId] == ["ami-00000001"]' >/dev/null \
+printf '%s' "$images" | jq -e '[.Images[].ImageId] == ["ami-fe1a7001"]' >/dev/null \
   || fail "ReadImages lists more than the declared image: $images"
 types="$(osc ReadVmTypes)" || fail "ReadVmTypes rejected: $types"
 printf '%s' "$types" | jq -e '[.VmTypes[].VmTypeName] == ["tinav6.c1r1p2"]' >/dev/null \
@@ -126,7 +126,7 @@ printf '%s' "$types" | jq -e '[.VmTypes[].VmTypeName] == ["tinav6.c1r1p2"]' >/de
 ok "one image and one type on offer, the declared ones"
 
 echo "- octl: the declared image and type still create"
-vm="$(osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2)" || fail "CreateVms refused the declared pair: $vm"
+vm="$(osc CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c1r1p2)" || fail "CreateVms refused the declared pair: $vm"
 vm_id="$(printf '%s' "$vm" | jq -r '.Vms[0].VmId // empty')"
 [ -n "$vm_id" ] || fail "no VmId in the answer: $vm"
 osc DeleteVms --VmIds "$vm_id" >/dev/null || fail "DeleteVms rejected"

--- a/tools/demo/network.tape
+++ b/tools/demo/network.tape
@@ -84,7 +84,7 @@ Type "SUB=$(osc ReadSubnets | jq -r .Subnets[0].SubnetId)"
 Enter
 Sleep 2s
 
-Type "osc CreateVms --ImageId ami-00000001 --VmType tinav6.c1r1p2 --SubnetId $SUB | jq -c .Vms[0]"
+Type "osc CreateVms --ImageId ami-fe1a7001 --VmType tinav6.c1r1p2 --SubnetId $SUB | jq -c .Vms[0]"
 Enter
 Sleep 5s
 

--- a/tools/falsify/specs/no-fixture-lives-in-the-minted-namespace.json
+++ b/tools/falsify/specs/no-fixture-lives-in-the-minted-namespace.json
@@ -1,0 +1,36 @@
+{
+  "mutations": [
+    {
+      "label": "a catalogue image moves back into the sanitiser's minting space, which is #395 verbatim",
+      "file": "internal/providers/outscale/catalog.go",
+      "package": "./internal/providers/outscale/",
+      "find": "\t\t{\"ImageId\": \"ami-fe1a7001\", \"ImageName\": \"Ubuntu-24.04-2025.01\",",
+      "replace": "\t\t{\"ImageId\": \"ami-00000001\", \"ImageName\": \"Ubuntu-24.04-2025.01\",",
+      "test": "TestTheCatalogueIdentifiersStayOutOfTheMintingSpace"
+    },
+    {
+      "label": "the same image, seen from the cross-pack scan rather than the pack's own test",
+      "file": "internal/providers/outscale/catalog.go",
+      "package": "./internal/cli/",
+      "find": "\t\t{\"ImageId\": \"ami-fe1a7001\", \"ImageName\": \"Ubuntu-24.04-2025.01\",",
+      "replace": "\t\t{\"ImageId\": \"ami-00000001\", \"ImageName\": \"Ubuntu-24.04-2025.01\",",
+      "test": "TestNoPackFixtureLivesInTheSanitisersMintingSpace"
+    },
+    {
+      "label": "the Exoscale default security group goes back to the first UUID every sanitised corpus mints",
+      "file": "internal/providers/exoscale/securitygroups.go",
+      "package": "./internal/cli/",
+      "find": "\tdefaultSecurityGroupID = \"fe1a7000-0000-4000-8000-000000000001\"",
+      "replace": "\tdefaultSecurityGroupID = \"00000000-0000-4000-8000-000000000001\"",
+      "test": "TestNoPackFixtureLivesInTheSanitisersMintingSpace"
+    },
+    {
+      "label": "the scan stops recognising a minted value, and its planted witness is what catches it: a control that finds nothing must first prove it can find",
+      "file": "internal/cli/fixtures_test.go",
+      "package": "./internal/cli/",
+      "find": "\t\t\tif corpus.Minted(candidate) {",
+      "replace": "\t\t\tif corpus.Minted(candidate) && false {",
+      "test": "TestNoPackFixtureLivesInTheSanitisersMintingSpace"
+    }
+  ]
+}

--- a/tools/ui/screenshots.sh
+++ b/tools/ui/screenshots.sh
@@ -60,7 +60,7 @@ post "$Z/ips" '{"project":"11111111-1111-1111-1111-111111111111"}'
 post "/vpc/v2/regions/fr-par/vpcs" '{"name":"demo-vpc"}'
 post "/vpc/v2/regions/fr-par/private-networks" '{"name":"demo-net","subnets":["10.10.0.0/24"]}'
 post "/api/v1/CreateKeypair" '{"KeypairName":"demo","PublicKey":"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD demo@feint"}'
-post "/api/v1/CreateVms" '{"ImageId":"ami-00000001","VmType":"tinav6.c1r1p2","KeypairName":"demo"}'
+post "/api/v1/CreateVms" '{"ImageId":"ami-fe1a7001","VmType":"tinav6.c1r1p2","KeypairName":"demo"}'
 post "/v2/ssh-key" '{"name":"exo-key","public-key":"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIr6pEFlAFO3YU0DNW/r8SkpjdbptN9ockkO2BtIolSD demo@feint"}'
 post "/v2/instance" '{"name":"exo-1","instance-type":{"id":"21624abb-764e-4def-81d7-9fc54b5957fb"},"template":{"id":"11111111-1111-1111-1111-111111111111"},"disk-size":10,"ssh-keys":[{"name":"exo-key"}]}'
 curl -sf "$Z/servers" -o /dev/null || true


### PR DESCRIPTION
# Summary

The sanitiser replaces a recording's identifiers with a counter: prefixed
identifiers as eight hexadecimal digits from `00000001`, UUIDs under
`00000000-0000-4000-8000-`, addresses inside `198.18.0.0/15`. A pack fixture
written in the same space is a value a recording can reach, and then a replay
names an object of **this** emulator where the recording named one of the
account. #395 measured `DeleteImage` and `UpdateImage` on an image that did not
exist, refused by the cloud with 400, replayed as `ami-00000002`, a catalogue
image, and refused here with 409 "belongs to the emulated catalogue": a
plausible verdict on a request nobody made, and two corpus exemptions to carry
it.

MEASURED ACROSS PACKS, NOT BY INSPECTION OF ONE CATALOGUE.

The issue asked for a rule testable across packs, and the test written for it
found **fourteen** fixtures where the issue named three, on `main` at 49dfa2c:

```text
internal/providers/outscale/catalog.go        ami-00000001..3   the images, twice (table, boot map)
internal/providers/outscale/catalog.go        pl-00000001..7    the net access point services
internal/providers/exoscale/securitygroups.go 00000000-0000-4000-8000-000000000001
                                              the default security group: the FIRST UUID
                                              every sanitised corpus of this pack hands out
```

The issue's own premise, "UUIDs are minted under `00000000-0000-4000-8000-`,
which a pack fixture would not use", was false by one fixture. In the Exoscale
corpora that UUID is the zone id of 59 recorded `list-zones` answers, so the
collision has produced no wrong verdict yet; it was one recording away from one.

WHAT MOVES, AND THE ONE THING HERE TO OBJECT TO.

The images to `ami-fe1a7001..3` and the services to `pl-fe1a7001..7`, where
#389 had already put the catalogue's snapshots and volumes; the default group to
`fe1a7000-0000-4000-8000-000000000001`. Every file that named the old
identifiers follows: the README, the quickstart, the stack declaration, the
conformance scripts and Terraform fixtures, the demo tape, the screenshots, the
tests. `docs/limits.md`'s boot table and the survey are dated rather than
rewritten. **A client that hardcoded `ami-00000001` changes one value**, and the
changelog says so under Changed; if that cost is not wanted on this release, the
alternative is to move the sanitiser's counter instead, which re-mints nothing
already committed and leaves the existing corpora colliding.

THE TEST, AND ITS WITNESS.

`TestNoPackFixtureLivesInTheSanitisersMintingSpace` (`internal/cli`) parses
every non-test Go file under `internal/providers` and reads every string
literal with `corpus.Minted`, the sanitiser's own recogniser, so the two cannot
drift apart; netmasks are skipped, since the sanitiser maps that closed set onto
itself. Before it reports nothing it reports a planted file carrying one value
of each family, or a scan that read nothing would pass by silence; the mutation
that blinds the recogniser goes red on that witness. The pack's own
`TestTheCatalogueIdentifiersStayOutOfTheMintingSpace` now covers the images and
the boot map beside the snapshots.

The two corpus exemptions naming this issue are gone, and `feint corpus --check`
compares the exchanges: 0 divergent findings nothing accepts. Four mutations
bite.

WHAT WAS NOT PLAYED, WRITTEN DOWN.

`prepush`, `corpus:check` and the falsification ran and are green. **No
conformance leg was played**: the station is held by a runtime measurement under
`incus-ovn`, and the owner plays the pass once on the assembled lot. What the
legs would prove: that every script and fixture renamed here still finds the
catalogue under its new identifiers (`terraform.sh` asserts `ami-fe1a7001` is
listed; `network.sh`, `balancer.sh`, `ssh.sh`, `parity.sh` create machines from
them; the Terraform fixtures and the quickstart name them).

## Type of change

- [x] A route added or changed (three fixture identifiers a client can read)
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Chore / tooling (the cross-pack test)

## Checklist

### Always

- [x] `mise run check` passes, through `mise run prepush`
- [x] No new external Go dependency (`go/parser` is the standard library)
- [x] `internal/core` still knows no provider: untouched; the test lives in
      `internal/cli` and walks `internal/providers` by path
- [x] Nothing in the diff could be written identically for another provider:
      the rule is held once, across packs, in `internal/cli`
- [x] `mise run testplan` was run, and what it printed was run except the
      conformance legs, named above with why and what they would prove

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] I ran `mise run conformance` myself — **not run**, deliberately, see
      above; written here rather than ticked
- [x] Every field name in the diff is unchanged; the values are fixtures of this
      emulator, chosen outside the space `internal/corpus/scan.go` recognises

### When a route is added or changed — otherwise N/A

- [x] The routes keep their upstream operations; none is added
- [ ] `mise run conformance` passes — **not run**, see above; the corpus replay
      is green with two exemptions fewer
- [x] The response was validated against the provider's own API description:
      the identifiers keep their prefixes and lengths, and the pre-commit hook
      "routes match the provider's API description" is green
- [x] What the client sends is read, or refused: unchanged
- [x] `mise run drift:update`: N/A, no operation changed hands

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated: the boot table names the new identifiers and
      dates the old ones
- [x] The README's generated tables: `feint docs --check` green through
      `prepush`; the README's quickstart command is prose and was renamed by
      hand

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: no runtime, no `FEINT_VM`, no container started. The boot map's keys
moved with the images, and `TestTheCatalogueIdentifiersStayOutOfTheMintingSpace`
holds that both tables carry the same identifiers.

## Related issues

Closes #395

## Conformance

Conformance, played on the owner's station on 2026-09-06 against the **assembled lot** (#700, #397, #396, #395, #124 cherry-picked onto `main` at bd935a8, `feint corpus --check` green with six exemptions fewer), `FEINT_VM` off:

- `mise run conformance`: every suite passed (scw CLI, tofu, octl with the corrected refusal probe, the Outscale tofu stack, the three example stacks applied, re-planned empty and destroyed, the quick start, tofu and exo on the Exoscale pack, exo on ch-gva-2, fault injection, the recorded refusals, `feint up`/`down`, the network suites, the balancer dataplane). Score: **375 of 395 routes proven by a real client**. 0 `FAIL`, finished in 324 s.
- `mise run conformance:leg -- fields`, the one leg where the omission gate judges: green, exit 0, score 370 of 395, 0 `FAIL`, and the omission gate named no field (225 s).

One observation that is not this lot's: the `scw` CLI prints `runtime error: invalid memory address or nil pointer dereference` during the "load balancer chain" step, the suite tolerates it, and the same line is in `main`'s last green CI run (2026-09-06 10:09, three occurrences). Worth its own issue; not opened here.
