### PR TITLE
docs(exoscale): thirteen undriven routes say which clients were read, and both were (#611)

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -876,16 +876,16 @@ left for a reader to infer from an absent token. A line disappears from
 this list the day a client drives its operation, and a test refuses a
 reason that outlived its cause.
 
-- `compute` — 4 operations — the CLI clears a field by sending the update with an empty value, so the per-field DELETE the API declares is never issued
-- `compute` — 1 operation — `exo compute instance snapshot show` lists the snapshots and picks the one it wants in the client, so the per-id read is never called
-- `compute` — 1 operation — `exo compute instance-template` offers register, list, show and delete, and no update, so a client cannot rename a template it owns
-- `compute` — 1 operation — `exo compute load-balancer service show` reads the balancer list and picks its service out of the balancer it found, so the per-id service read is never called
-- `compute` — 1 operation — `exo compute load-balancer service update --description ""` sends only the healthcheck block it re-sends on every call, so this CLI clears no field by either route and the per-field DELETE is never issued
-- `compute` — 1 operation — `exo compute load-balancer update --description ""` sends an empty body rather than the empty value, so this CLI clears no field by either route and the per-field DELETE is never issued
-- `compute` — 1 operation — copying a template targets another zone, and this emulator serves exactly one, so the CLI has nothing to copy to and no subcommand that would ask
-- `compute` — 1 operation — the CLI's --from-snapshot promotes through export-snapshot and a URL, which this pack declines, so it never issues the promote call the SDK declares
-- `compute` — 1 operation — the list this pack serves is empty, because an emulated account owns no dedicated hardware, so no client ever holds an id to read
-- `quotas` — 1 operation — `exo limits` reads the whole quota list and prints it, so the per-name read has no client path even though the SDK declares one
+- `compute` — 4 operations — neither published client issues it: the CLI clears a field by sending the update with an empty value, and the Terraform provider (v0.71.0) makes no per-field reset call at all, its own code holding no Reset*() call site
+- `compute` — 1 operation — `exo compute instance snapshot show` lists the snapshots and picks the one it wants in the client, so the per-id read is never called, and the Terraform provider (v0.71.0) reads block-storage snapshots by id but never an instance one
+- `compute` — 1 operation — `exo compute instance-template` offers register, list, show and delete, and no update, so a client cannot rename a template it owns, and the Terraform provider (v0.71.0) only ever calls GetTemplate
+- `compute` — 1 operation — `exo compute load-balancer service show` reads the balancer list and picks its service out of the balancer it found, so the per-id service read is never called, and the Terraform provider does the same: resource_exoscale_nlb_service.go reads the balancer by id and takes its service from the answer
+- `compute` — 1 operation — `exo compute load-balancer service update --description ""` sends only the healthcheck block it re-sends on every call, so this CLI clears no field by either route, and the Terraform provider (v0.71.0) issues no per-field reset either
+- `compute` — 1 operation — `exo compute load-balancer update --description ""` sends an empty body rather than the empty value, so this CLI clears no field by either route, and the Terraform provider (v0.71.0) issues no per-field reset either
+- `compute` — 1 operation — copying a template targets another zone, and this emulator serves exactly one, so the CLI has nothing to copy to and no subcommand that would ask; the Terraform provider (v0.71.0) never copies one either
+- `compute` — 1 operation — the CLI's --from-snapshot promotes through export-snapshot and a URL, which this pack declines, so it never issues the promote call the SDK declares, and the Terraform provider (v0.71.0) holds no Promote*() call site at all
+- `compute` — 1 operation — the list this pack serves is empty, because an emulated account owns no dedicated hardware, so no client ever holds an id to read; the Terraform provider does model deploy targets and is stopped by the same emptiness, not by a gap in the client
+- `quotas` — 1 operation — `exo limits` reads the whole quota list and prints it, so the per-name read has no client path even though the SDK declares one, and the word Quota does not appear anywhere in the Terraform provider's own code (v0.71.0)
 
 ### Declined on purpose (270)
 

--- a/internal/providers/exoscale/pack.go
+++ b/internal/providers/exoscale/pack.go
@@ -220,7 +220,7 @@ func (p *Pack) Routes() []emulator.Route {
 		// deleting the field. `exo compute elastic-ip update --description ""`
 		// issues a PUT and no DELETE, and so does the private network one.
 		{Method: "DELETE", Path: "/v2/private-network/{id}/{field}", Operation: operation("reset-private-network-field"), Handler: p.resetPrivateNetworkField,
-			Undriven: "the CLI clears a field by sending the update with an empty value, so the per-field DELETE the API declares is never issued"},
+			Undriven: "neither published client issues it: the CLI clears a field by sending the update with an empty value, and the Terraform provider (v0.71.0) makes no per-field reset call at all, its own code holding no Reset*() call site"},
 		{Method: "PUT", Path: "/v2/private-network/{id}:attach", Operation: operation("attach-instance-to-private-network"), Handler: p.attachInstanceToPrivateNetwork},
 		{Method: "PUT", Path: "/v2/private-network/{id}:detach", Operation: operation("detach-instance-from-private-network"), Handler: p.detachInstanceFromPrivateNetwork},
 		{Method: "PUT", Path: "/v2/private-network/{id}:update-ip", Operation: operation("update-private-network-instance-ip"), Handler: p.updatePrivateNetworkInstanceIP},
@@ -238,7 +238,7 @@ func (p *Pack) Routes() []emulator.Route {
 			// hardware Exoscale assigns, not something a client creates. With
 			// nothing in the list there is no id to read, and seeding a fake one
 			// would be inventing inventory — the thing docs/limits.md refuses.
-			Undriven: "the list this pack serves is empty, because an emulated account owns no dedicated hardware, so no client ever holds an id to read"},
+			Undriven: "the list this pack serves is empty, because an emulated account owns no dedicated hardware, so no client ever holds an id to read; the Terraform provider does model deploy targets and is stopped by the same emptiness, not by a gap in the client"},
 
 		// The first call the official CLI makes, and the address every call
 		// after it uses. Measured, not assumed: see catalog.go.
@@ -252,7 +252,7 @@ func (p *Pack) Routes() []emulator.Route {
 		{Method: "POST", Path: "/v2/instance/{id}:create-snapshot", Operation: operation("create-snapshot"), Handler: p.createSnapshot},
 		{Method: "GET", Path: "/v2/snapshot", Operation: operation("list-snapshots"), Handler: p.listSnapshots},
 		{Method: "GET", Path: "/v2/snapshot/{id}", Operation: operation("get-snapshot"), Handler: p.getSnapshot,
-			Undriven: "`exo compute instance snapshot show` lists the snapshots and picks the one it wants in the client, so the per-id read is never called"},
+			Undriven: "`exo compute instance snapshot show` lists the snapshots and picks the one it wants in the client, so the per-id read is never called, and the Terraform provider (v0.71.0) reads block-storage snapshots by id but never an instance one"},
 		{Method: "DELETE", Path: "/v2/snapshot/{id}", Operation: operation("delete-snapshot"), Handler: p.deleteSnapshot},
 		{Method: "POST", Path: "/v2/instance/{id}:revert-snapshot", Operation: operation("revert-instance-to-snapshot"), Handler: p.revertInstanceToSnapshot},
 		// The CLI has a flag for this — `instance-template register
@@ -262,21 +262,21 @@ func (p *Pack) Routes() []emulator.Route {
 		// back an object-storage address this emulator does not serve), so the
 		// whole path stops before anything could reach :promote.
 		{Method: "POST", Path: "/v2/snapshot/{id}:promote", Operation: operation("promote-snapshot-to-template"), Handler: p.promoteSnapshotToTemplate,
-			Undriven: "the CLI's --from-snapshot promotes through export-snapshot and a URL, which this pack declines, so it never issues the promote call the SDK declares"},
+			Undriven: "the CLI's --from-snapshot promotes through export-snapshot and a URL, which this pack declines, so it never issues the promote call the SDK declares, and the Terraform provider (v0.71.0) holds no Promote*() call site at all"},
 		{Method: "POST", Path: "/v2/template", Operation: operation("register-template"), Handler: p.registerTemplate},
 		{Method: "POST", Path: "/v2/template/{id}", Operation: operation("copy-template"), Handler: p.copyTemplate,
-			Undriven: "copying a template targets another zone, and this emulator serves exactly one, so the CLI has nothing to copy to and no subcommand that would ask"},
+			Undriven: "copying a template targets another zone, and this emulator serves exactly one, so the CLI has nothing to copy to and no subcommand that would ask; the Terraform provider (v0.71.0) never copies one either"},
 		{Method: "PUT", Path: "/v2/template/{id}", Operation: operation("update-template"), Handler: p.updateTemplate,
-			Undriven: "`exo compute instance-template` offers register, list, show and delete, and no update, so a client cannot rename a template it owns"},
+			Undriven: "`exo compute instance-template` offers register, list, show and delete, and no update, so a client cannot rename a template it owns, and the Terraform provider (v0.71.0) only ever calls GetTemplate"},
 		{Method: "DELETE", Path: "/v2/template/{id}", Operation: operation("delete-template"), Handler: p.deleteTemplate},
 		// The account-level reads and the two field resets, same triage (#173).
 		{Method: "GET", Path: "/v2/organization", Operation: operation("get-organization"), Handler: p.getOrganization},
 		{Method: "GET", Path: "/v2/event", Operation: operation("list-events"), Handler: p.listEvents},
 		{Method: "POST", Path: "/v2/instance/{id}:enable-tpm", Operation: operation("enable-tpm"), Handler: p.enableTPM},
 		{Method: "DELETE", Path: "/v2/instance/{id}/{field}", Operation: operation("reset-instance-field"), Handler: p.resetInstanceField,
-			Undriven: "the CLI clears a field by sending the update with an empty value, so the per-field DELETE the API declares is never issued"},
+			Undriven: "neither published client issues it: the CLI clears a field by sending the update with an empty value, and the Terraform provider (v0.71.0) makes no per-field reset call at all, its own code holding no Reset*() call site"},
 		{Method: "DELETE", Path: "/v2/elastic-ip/{id}/{field}", Operation: operation("reset-elastic-ip-field"), Handler: p.resetElasticIPField,
-			Undriven: "the CLI clears a field by sending the update with an empty value, so the per-field DELETE the API declares is never issued"},
+			Undriven: "neither published client issues it: the CLI clears a field by sending the update with an empty value, and the Terraform provider (v0.71.0) makes no per-field reset call at all, its own code holding no Reset*() call site"},
 		{Method: "GET", Path: "/v2/instance-type", Operation: operation("list-instance-types"), Handler: p.listInstanceTypes},
 		{Method: "GET", Path: "/v2/instance-type/{id}", Operation: operation("get-instance-type"), Handler: p.getInstanceType},
 
@@ -330,7 +330,7 @@ func (p *Pack) Routes() []emulator.Route {
 		{Method: "PUT", Path: "/v2/instance-pool/{id}:scale", Operation: operation("scale-instance-pool"), Handler: p.scaleInstancePool},
 		{Method: "PUT", Path: "/v2/instance-pool/{id}:evict", Operation: operation("evict-instance-pool-members"), Handler: p.evictInstancePoolMembers},
 		{Method: "DELETE", Path: "/v2/instance-pool/{id}/{field}", Operation: operation("reset-instance-pool-field"), Handler: p.resetInstancePoolField,
-			Undriven: "the CLI clears a field by sending the update with an empty value, so the per-field DELETE the API declares is never issued"},
+			Undriven: "neither published client issues it: the CLI clears a field by sending the update with an empty value, and the Terraform provider (v0.71.0) makes no per-field reset call at all, its own code holding no Reset*() call site"},
 
 		// SSH keys. On the critical path of a create: the official CLI
 		// registers one of its own before it posts the instance.
@@ -341,7 +341,7 @@ func (p *Pack) Routes() []emulator.Route {
 		// counted rather than invented.
 		{Method: "GET", Path: "/v2/quota", Operation: operation("list-quotas"), Handler: p.listQuotas},
 		{Method: "GET", Path: "/v2/quota/{name}", Operation: operation("get-quota"), Handler: p.getQuota,
-			Undriven: "`exo limits` reads the whole quota list and prints it, so the per-name read has no client path even though the SDK declares one"},
+			Undriven: "`exo limits` reads the whole quota list and prints it, so the per-name read has no client path even though the SDK declares one, and the word Quota does not appear anywhere in the Terraform provider's own code (v0.71.0)"},
 		{Method: "GET", Path: "/v2/ssh-key/{name}", Operation: operation("get-ssh-key"), Handler: p.getSSHKey},
 		{Method: "DELETE", Path: "/v2/ssh-key/{name}", Operation: operation("delete-ssh-key"), Handler: p.deleteSSHKey},
 
@@ -367,7 +367,7 @@ func (p *Pack) Routes() []emulator.Route {
 		{Method: "DELETE", Path: "/v2/load-balancer/{id}", Operation: operation("delete-load-balancer"), Handler: p.deleteLoadBalancer},
 		{Method: "POST", Path: "/v2/load-balancer/{id}/service", Operation: operation("add-service-to-load-balancer"), Handler: p.addServiceToLoadBalancer},
 		{Method: "GET", Path: "/v2/load-balancer/{id}/service/{serviceID}", Operation: operation("get-load-balancer-service"), Handler: p.getLoadBalancerService,
-			Undriven: "`exo compute load-balancer service show` reads the balancer list and picks its service out of the balancer it found, so the per-id service read is never called"},
+			Undriven: "`exo compute load-balancer service show` reads the balancer list and picks its service out of the balancer it found, so the per-id service read is never called, and the Terraform provider does the same: resource_exoscale_nlb_service.go reads the balancer by id and takes its service from the answer"},
 		{Method: "PUT", Path: "/v2/load-balancer/{id}/service/{serviceID}", Operation: operation("update-load-balancer-service"), Handler: p.updateLoadBalancerService},
 		{Method: "DELETE", Path: "/v2/load-balancer/{id}/service/{serviceID}", Operation: operation("delete-load-balancer-service"), Handler: p.deleteLoadBalancerService},
 		// The two per-field resets, and their reason is NOT the sentence every
@@ -380,9 +380,9 @@ func (p *Pack) Routes() []emulator.Route {
 		// field at all, by update or by reset, and copying the familiar sentence
 		// here would have recorded a behaviour this client does not have.
 		{Method: "DELETE", Path: "/v2/load-balancer/{id}/{field}", Operation: operation("reset-load-balancer-field"), Handler: p.resetLoadBalancerField,
-			Undriven: "`exo compute load-balancer update --description \"\"` sends an empty body rather than the empty value, so this CLI clears no field by either route and the per-field DELETE is never issued"},
+			Undriven: "`exo compute load-balancer update --description \"\"` sends an empty body rather than the empty value, so this CLI clears no field by either route, and the Terraform provider (v0.71.0) issues no per-field reset either"},
 		{Method: "DELETE", Path: "/v2/load-balancer/{id}/service/{serviceID}/{field}", Operation: operation("reset-load-balancer-service-field"), Handler: p.resetLoadBalancerServiceField,
-			Undriven: "`exo compute load-balancer service update --description \"\"` sends only the healthcheck block it re-sends on every call, so this CLI clears no field by either route and the per-field DELETE is never issued"},
+			Undriven: "`exo compute load-balancer service update --description \"\"` sends only the healthcheck block it re-sends on every call, so this CLI clears no field by either route, and the Terraform provider (v0.71.0) issues no per-field reset either"},
 	})
 }
 


### PR DESCRIPTION
## What this closes

#611 sorted eighteen undriven Exoscale routes into three families and asked for
a triage decision on two of them. It also named, in its own "Not established"
list, the one measurement nobody had made:

> Whether a returning Terraform would drive the six `reset-*-field` routes. The
> provider was not read for it; only the `exo` half is measured.

Half of the issue answered itself. Terraform returned at #644 on the published
v0.71.0, and regenerating the evidence register at #631 showed **five of the
eighteen driven** — their `Route.Undriven` reasons were removed there. The
remaining thirteen are what this PR is about.

## Why read the provider rather than trust the register

The register says our stacks do not drive these thirteen. A reason printed in
`docs/routes.md` says something stronger: *this client does not reach it*. Those
are different claims, and only the second is worth writing down, so the provider
was read rather than inferred from.

Measured on the published provider's own source, `vendor/` excluded, 2026-09-06:

| what | reading |
|---|---|
| per-field resets (6 routes) | **no `Reset*()` call site at all** in the provider's code |
| template copy / update / promote | none; the only template call is `GetTemplate` |
| `get-quota` | the word `Quota` does not appear in the provider's code |
| `get-snapshot` | block-storage snapshots are read by id, an instance snapshot never |
| `get-load-balancer-service` | read out of the balancer, exactly like `exo` (`resource_exoscale_nlb_service.go`) |
| `get-deploy-target` | the provider **does** model deploy targets, and the empty list stops it |

That last row is the one worth keeping: it is the only one of the thirteen whose
reason is about this emulator rather than about a client, and it now says so.

## The instrument lied first, twice

Worth recording because both failures looked exactly like findings.

**First**: the sweep answered zero for all seven operations — and zero for
`GetInstance`, which the register calls driven. That is the harness, not the
subject: `grep -v '/vendor/'` does not match a path printed as `vendor/…`, and
the directory list was passed unquoted to a zsh that does not word-split.
Rewritten in a file under bash, the witness reads `GetInstance 13`,
`GetElasticIP 5`, `GetInstancePool 5`.

**Second**, subtler: `GetLoadBalancer` and `GetOperation` still read zero while
the register calls both driven. Neither is a contradiction, both are spellings.
The provider reaches the balancer as `GetNetworkLoadBalancer` (the egoscale v2
wrapper), and it never calls `GetOperation` itself — the SDK's `Wait` helper
does, at `egoscale/v3/api.go:74`, under every `client.Wait(...)` the provider
issues. That is the polling #631's commit inferred from behaviour, now read in
source.

Without the witness half, this PR would have shipped seven confident zeros, one
of which was false.

## What is deliberately not here

- **No changelog entry.** `CHANGELOG.md`'s own header earns a line for a
  response shape a client can observe, or a limit that moved. This moves
  neither, and the count does not move either: thirteen stay thirteen. What
  changed is that each reason now names both published clients instead of one.
- **No new route, no new behaviour.** `TestEveryUndrivenOperationSaysWhy`
  already fails the day a client drives one of these; that is the guard, and it
  is the one that produced this work in the first place.
- The issue's third open item — whether the `block`, `ipam` and `vpc`
  singletons have causes of their own — is **not** answered here. Those seven
  Scaleway-side reasons already name Terraform explicitly, so they are not the
  same defect; if they deserve a pass, it is a separate one.

## Checks

- `mise run prepush` exits 0
- `mise run docs:coverage` regenerated `docs/routes.md`; the Exoscale list still
  reads 13, with longer reasons

## Related issues

Closes #611
