### PR TITLE
feat(outscale): nine of the ten operations with no refusal get one, and the tenth says why it cannot (#615)

### DIFF
--- a/internal/providers/outscale/pack.go
+++ b/internal/providers/outscale/pack.go
@@ -260,7 +260,8 @@ func (p *Pack) Routes() []emulator.Route {
 		// page on it, and on the control plane an fGPU is the shape of a
 		// volume rather than of a machine. The catalogue is a reading of the
 		// real one, so the create can refuse a model the cloud does not offer.
-		p.route("ReadFlexibleGpuCatalog", p.readFlexibleGpuCatalog),
+		unearnable(p.route("ReadFlexibleGpuCatalog", p.readFlexibleGpuCatalog),
+			nothingToRefuse("ReadFlexibleGpuCatalogRequest declares DryRun and nothing else")),
 		p.route("CreateFlexibleGpu", p.createFlexibleGpu),
 		p.route("ReadFlexibleGpus", p.readFlexibleGpus),
 		p.route("UpdateFlexibleGpu", p.updateFlexibleGpu),

--- a/tools/conformance/outscale/octl.sh
+++ b/tools/conformance/outscale/octl.sh
@@ -1098,6 +1098,12 @@ refuse_call 4001 ReadKeypairs          --Filters.KeypairIds key-feintnone
 refuse_call 4001 ReadSecurityGroups    --Filters.InboundRuleAccountIds 000000000001
 refuse_call 4001 ReadRouteTables       --Filters.LinkRouteTableLinkRouteTableIds rtbassoc-feintnone
 refuse_call 4001 ReadNics              --Filters.Descriptions none
+# FiltersLoadBalancer declares LoadBalancerNames and States; this pack serves
+# the first alone (loadbalancers.go). A name that matches nothing is NOT a
+# refusal — the real cloud answers 200 with an empty list, recorded in
+# corpus/outscale/oapi-cli-lb-shapes.jsonl:145 — so States is the filter that
+# makes this call refusable without diverging from upstream (#615).
+refuse_call 4001 ReadLoadBalancers      --Filters.States available
 refuse_call 4001 ReadVolumes           --payload '{"Filters":{"CreationDates":["2026-01-01T00:00:00.000Z"]}}'
 # AccountAliases was the probe on ReadSnapshots and ReadImages until #700, when
 # the filter became served on both (the contract's own ReadImages example uses
@@ -1154,7 +1160,9 @@ osc ReadFlexibleGpus --Filters.VmIds "$vm_id" \
   | jq -e --arg id "$gpu_id" '.FlexibleGpus | length == 1 and .[0].FlexibleGpuId == $id and .[0].State == "attached"' >/dev/null \
   || fail "the attached fGPU is not listed against its machine"
 
-# The two refusals this family owns, on the shape #621 settled for volumes.
+# Two of this family's refusals, on the shape #621 settled for volumes. They
+# run inside the BEHAVIOUR bracket, so they prove the lifecycle and credit
+# nothing on `negative`; the span below is what credits the axis (#615).
 refuse_call 9029 LinkFlexibleGpu --FlexibleGpuId "$gpu_id" --VmId "$vm_id"
 osc UnlinkFlexibleGpu --FlexibleGpuId "$gpu_id" >/dev/null || fail "UnlinkFlexibleGpu rejected"
 refuse_call 9029 UnlinkFlexibleGpu --FlexibleGpuId "$gpu_id"
@@ -1172,6 +1180,61 @@ osc ReadFlexibleGpus --Filters.FlexibleGpuIds "$gpu_id" \
   | jq -e '.FlexibleGpus | length == 0' >/dev/null || fail "the deleted fGPU is still listed"
 prove_end "$gpuspan"
 ok "an fGPU from the catalogue: allocated, attached, detached, updated, deleted"
+
+# The refusals this family owns, in a span of their own.
+#
+# Nothing here is new in the pack: all six already exist in flexiblegpu.go, and
+# two of them already ran above. What was missing is the bracket. A refusal
+# inside `prove_begin behaviour` proves a lifecycle; only `prove_begin negative`
+# attributes it to the `negative` axis, and coverage/evidence.json carried
+# `negative: false` for all seven fGPU operations while octl.sh was already
+# driving two of their refusals (#615).
+echo "- every refusal the flexible GPU family owns, credited to the axis"
+gpuneg="$(prove_begin negative)"
+# A model the catalogue does not offer. The join the block above makes — the
+# create names a model the catalogue offered — is what gives this one meaning:
+# the catalogue decides which models exist, so a name outside it is refused for
+# a measured reason rather than because a constant says so.
+refuse_call 4001 CreateFlexibleGpu --ModelName nvidia-not-in-this-catalogue --SubregionName eu-west-2a
+# FiltersFlexibleGpu declares eight filters and this pack serves all eight, so
+# the declared-but-unserved refusal above does not exist for this call. What is
+# left is a filter name the API declares nowhere, which the real cloud refuses
+# too — its filter schemas are closed — so this is a firmer refusal than the
+# sixteen above rather than a weaker one.
+#
+# Two other shapes were tried here first and both were ACCEPTED, which the suite
+# caught as "accepted what it must refuse": a scalar where FlexibleGpuIds
+# declares an array, and a string where DeleteOnVmDeletion declares a boolean.
+# The emulator refuses both — 400/4001, verified with curl straight at the route
+# — so what those two measured is that octl types each filter itself and never
+# puts such a value on the wire (#615).
+# The third shape, and the third acceptance: octl strips a filter name it does
+# not know, exactly as it dropped the two mistyped values. So ReadFlexibleGpus
+# keeps no `negative` and is NOT declared unearnable either — the repository's
+# own control refuses that declaration, and it is right to: the request schema
+# does carry Filters, so a refusable request is composable in principle, just
+# not by this client. Naming that would need a fourth Cause with a control of
+# its own, which is not this issue's subject (#615).
+neg_gpu="$(osc CreateFlexibleGpu --ModelName "$gpu_model" --Generation "$gpu_gen" \
+  --SubregionName eu-west-2a | jq -r '.FlexibleGpu.FlexibleGpuId')"
+[ -n "$neg_gpu" ] || fail "no FlexibleGpuId for the refusal span"
+# Detached: unlinking one attached to nothing.
+refuse_call 9029 UnlinkFlexibleGpu --FlexibleGpuId "$neg_gpu"
+osc LinkFlexibleGpu --FlexibleGpuId "$neg_gpu" --VmId "$vm_id" >/dev/null \
+  || fail "LinkFlexibleGpu rejected inside the refusal span"
+# Attached: attaching again, and deleting, are both refused — the delete for the
+# reason the volume delete is, a client that removed what a machine still claims
+# would find the object gone and the machine still holding it.
+refuse_call 9029 LinkFlexibleGpu --FlexibleGpuId "$neg_gpu" --VmId "$vm_id"
+refuse_call 9029 DeleteFlexibleGpu --FlexibleGpuId "$neg_gpu"
+# An identifier that names nothing, which is the only refusal the update owns.
+refuse_call 5063 UpdateFlexibleGpu --payload '{"FlexibleGpuId":"fgpu-00000000","DeleteOnVmDeletion":true}'
+prove_end "$gpuneg"
+osc UnlinkFlexibleGpu --FlexibleGpuId "$neg_gpu" >/dev/null \
+  || fail "UnlinkFlexibleGpu rejected while clearing the refusal span"
+osc DeleteFlexibleGpu --FlexibleGpuId "$neg_gpu" >/dev/null \
+  || fail "DeleteFlexibleGpu rejected while clearing the refusal span"
+ok "an absent model, a double attach, a detach of nothing, a delete of an attached one, an absent id"
 
 echo "- the tag filters select, exclude, and answer the object with its tags"
 tagspan="$(prove_begin behaviour)"


### PR DESCRIPTION
#615 counted three operations missing a refusal on 2026-08-29 and asked for a
decision on each. The number is ten: #619 added the Flexible GPU family after
the issue was written, and none of its seven operations is credited on
`negative`.

WHAT THE READING MOVED, TWICE, IN OPPOSITE DIRECTIONS.

Two of the original three were answered before the issue was filed.
CreateInternetService and ReadRegions already carry `nothingToRefuse`, with the
reasoning the issue asked for: their request schemas declare DryRun and nothing
else, so no client can name anything wrongly. The refusals the issue imagined
for CreateInternetService — an internet service already attached, a Net that
does not exist — belong to LinkInternetService, which is driven and refuses
(400/5001 in the corpus).

The third moved the other way. The issue expected ReadLoadBalancers might have
to be declined because the real cloud answers 200 with an empty list for a name
that matches nothing, and the corpus confirms exactly that at
oapi-cli-lb-shapes.jsonl:145 — the same balancer full at line 15 and empty at
145, after its delete. True, and about a different question:
FiltersLoadBalancer declares LoadBalancerNames AND States, and
loadBalancerFilters serves only the first. So there is a request valid to the
client and to the API that this pack refuses, and it is the same one the filter
table already drives sixteen times.

THE FGPU FAMILY NEEDED NO NEW REFUSAL AT ALL.

Five already exist in flexiblegpu.go, and two of them were already driven by
octl.sh. They ran inside `prove_begin behaviour`, so they proved a lifecycle and
credited nothing: `prove_begin negative` is what attributes a refusal to the
axis. The fix is a bracket, not a behaviour.

Measured rather than argued. With the span opened and the refusals driven, the
emulator credits exactly six operations:

    osc/Client.CreateFlexibleGpu     osc/Client.LinkFlexibleGpu
    osc/Client.DeleteFlexibleGpu     osc/Client.UnlinkFlexibleGpu
    osc/Client.ReadLoadBalancers     osc/Client.UpdateFlexibleGpu

ReadFlexibleGpuCatalog is the seventh, declared rather than earned:
its request declares DryRun and nothing else, and it answers from a table in
the binary, so nothing it reads can fail either.

THE TENTH RESISTS BOTH ROUTES, AND THAT IS THE RESULT RATHER THAN A GAP.

ReadFlexibleGpus was tried three times and accepted all three:

    {"Filters":{"DeleteOnVmDeletion":"not-a-boolean"}}   accepted
    {"Filters":{"FlexibleGpuIds":"fgpu-12345678"}}       accepted
    {"Filters":{"NoSuchFilterExists":["x"]}}             accepted

The emulator refuses all three, 400/4001, verified with curl straight at the
route. So what the three acceptances measure is octl: it types every filter
itself and never puts such a value on the wire. FiltersFlexibleGpu declares
eight filters and this pack serves all eight, so the declared-but-unserved
refusal is unavailable too.

It is NOT declared `nothingToRefuse`, and the attempt to declare it is why:
TestAnUnearnableNegativeHasNothingToRefuse refused it, reading the request
SCHEMA rather than the prose — ReadFlexibleGpusRequest declares Filters beside
DryRun, so a refusable request is composable in principle, just not by this
client. Saying that would need a fourth Cause with a control of its own, and
inventing vocabulary so a number reaches 100 % is the move this repository
exists to refuse. The reason is written where the line would have gone.

So Outscale is one operation from complete on four axes, not three, and the one
that remains is measured rather than untried.

WHAT IS NOT HERE. `coverage/evidence.json` still reads `negative: false` for the
six earned above: regenerating it runs `evidence:update`, whose second leg needs
machines, and this branch was worked with the runtime deliberately untouched.
The span's own answer above is the proof that the six are credited; the register
will carry it at the next regeneration. No changelog entry: no response shape
and no limit moved, which is what CHANGELOG.md's own header earns a line for.

Closes #615

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Checks

- `mise run prepush` exits 0
- `mise run conformance:leg -- octl` exits 0 (control plane only, `FEINT_VM` off: no machines were started for this branch)
- The credit list above comes from `POST /_feint/assert/<id>`, driven with curl against a fresh emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
