### PR TITLE
docs(machine): the reply door is measured on both shapes, and it is not what decides (#672)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -31,7 +31,7 @@
 >
 > **Prouvé** : 375 des 395 opérations montées sont pilotées par un vrai client, à chaque pull request. `scw`, `octl`, `exo`, Terraform et OpenTofu tournent contre l'émulateur en CI, et les machines démarrent réellement : connexion ssh sur le compte par défaut de chaque provider, subnets isolés, pare-feu qui filtre. La chaîne complète est décrite dans [docs/conformance.md](docs/conformance.md).
 >
-> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 55 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
+> **Pas prouvé** : quotas, prix, capacité réelle, validation des identifiants, authentification, cohérence à terme. Les 56 sections de [docs/limits.md](docs/limits.md) disent chacune ce qu'elle coûte. Un émulateur avec un seul compte implicite et aucune grille tarifaire devrait inventer ces chiffres, et quelqu'un agirait dessus.
 >
 > **Inconnu** : 20 opérations sont montées et n'ont jamais été pilotées par un client. Chacune dit pourquoi aucun client officiel ne l'atteint, à la route et dans [docs/routes.md](docs/routes.md). Elles sont comptées plutôt qu'escamotées, une par une, dans [coverage/evidence.json](coverage/evidence.json).
 >

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 >
 > **Proven**: 375 of the 395 mounted operations are driven by a real client, on every pull request: each pack's own official CLI, and an infrastructure engine wherever a pack admits one, all of them running against the emulator in CI, and machines really boot: an ssh login on each provider's own default account, isolated subnets, a firewall that filters. The whole chain is described in [docs/conformance.md](docs/conformance.md).
 >
-> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 55 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
+> **Not proven**: quotas, prices, real capacity, identifier validation, authentication, eventual consistency. The 56 sections of [docs/limits.md](docs/limits.md) each say what one costs. An emulator with a single implicit account and no price list would have to invent those figures, and somebody would act on them.
 >
 > **Unknown**: 20 operations are mounted and have never been driven by a client. Every one of them states why no official client reaches it, at the route and in [docs/routes.md](docs/routes.md). They are counted rather than glossed, one by one, in [coverage/evidence.json](coverage/evidence.json).
 >

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2241,6 +2241,99 @@ Consequences, stated rather than implied:
   papered over; widening the machine layer's contract is the boundary work of
   the architecture audit (#514), not a patch.
 
+## Which door a reply leaves by, and why it does not decide (#672)
+
+A machine holding a public address has to answer at that address. #660 named the
+failure in one sentence — *"its reply was leaving by a door the request had not
+come in through"* — and #672 asked for the door to be measured per machine
+shape rather than deduced, because a verifier that invented its expected values
+would be a second reconciler, wrong with the same confidence as the first.
+
+It is measured now, and the answer is that **the door is not what decides**.
+
+### The four readings, 2026-09-07
+
+One emulator per mode, a Scaleway server holding a flexible IP on a private
+network, both orders of construction. The service is proved listening from
+inside the guest by reading `/proc/net/tcp` for state `0A` before any
+reachability verdict, and the reader itself is checked against a planted witness
+first (`fnl_listen_reader_control`), because an instrument that cannot prove
+itself turns every "nothing is listening" into a measurement of the harness.
+
+| mode | order | the door: `ip route get <peer> from <public>` | neighbour | station reaches it |
+|---|---|---|---|---|
+| `incus-ovn` | address first, NIC hot | `dev eth1`, on-link, no `via` | `INCOMPLETE` | **no** |
+| `incus-ovn` | NIC cold, then address | `dev eth0`, on-link, no `via` | `INCOMPLETE` | **no** |
+| `incus` (bridge) | address first, NIC hot | `dev eth1`, on-link, no `via` | resolved (`DELAY`) | yes |
+| `incus` (bridge) | NIC cold, then address | `dev eth0`, on-link, no `via` | `REACHABLE` | yes |
+
+**The door reads the same in all four.** A `door` claim comparing `via` and
+`dev` — which is what `machine.door.Check` compares — would report `held` on the
+two machines that answer nobody. That is why no door claim is derived from this
+table: the silence in `claims.go` stays, and it is now silence for a measured
+reason rather than for an unmeasured one.
+
+### What actually differs: the peer, not the door
+
+A published address is reached **through the uplink**, so the address the
+station answers from is not its LAN address. Read on the station while the
+machine is alive:
+
+```
+--vm incus-ovn   203.0.113.2 dev feint-uplink src 10.209.83.1
+--vm incus       203.0.113.2 via 10.211.0.2 dev fnt-943cfdf1d2c src 10.211.0.1
+```
+
+So the guest must reply to `10.209.83.1` under OVN, and to `10.211.0.1` under
+the bridge. The first is the uplink's own address and is **not on the guest's
+subnet**; the second is the bridge's gateway and **is**. The guest's route to
+either is on-link, so it resolves the peer itself, and only one of the two can
+be resolved:
+
+```
+--vm incus-ovn   10.209.83.1 dev eth1  INCOMPLETE      <- nobody answers the ARP
+--vm incus       10.211.0.1  dev eth0  REACHABLE
+```
+
+The request lands either way — one connection in `SYN_RECV` inside the guest
+while the station dials, under OVN — so the emulator is not dropping anything
+inbound. It is the reply that never reaches the wire.
+
+The on-link route itself is DHCP's: `10.209.83.1 dev eth1 proto dhcp scope
+link`. `systemd-networkd` lays an on-link `/32` toward every DNS server a lease
+announces (`RoutesToDNS=`), and the OVN network announces the uplink as its
+resolver. A `/32` beats any default route by longest prefix, which is why #672's
+two variants of this shape read *"same gateway, same device, opposite results"*:
+the gateway and device were never the deciding part.
+
+### What the routed NIC does, per mode
+
+`docs/limits.md` has described the routed shape as keeping `default via
+169.254.0.1` even when a private NIC arrives later. That holds **in bridge
+mode**, where the same reading shows both routes side by side and the routed
+interface carrying the way out:
+
+```
+--vm incus     default via 169.254.0.1 dev eth0
+               default via 10.211.0.1 dev eth1 proto dhcp src 10.211.0.2
+               1.1.1.1 from 203.0.113.2 via 169.254.0.1 dev eth0
+```
+
+Under OVN it does not. The routed device exists — `nictype: routed`,
+`ipv4.host_address: 169.254.0.1` — and carries **no address at all** in the
+guest, so it lays no default route, and the address rides the managed NIC
+instead as `ipv4.routes.external`. The guest then has no default route of any
+kind, only the RFC1918 aggregates, and `ip route get 1.1.1.1` answers `Network
+is unreachable`. That is the outbound half #695 is about, and this section is
+where its cause is recorded.
+
+### What is not measured here
+
+Whether the real cloud's reply leaves by the interface carrying the public
+address, and with which next hop. No recording carries it. What is measured is
+this emulator's behaviour and the difference between its two modes, which is
+what a fix has to preserve on one side and change on the other.
+
 ## Subnet isolation depends on the runtime mode
 
 Upstream, two private networks of two different VPCs do not reach each other.

--- a/internal/core/machine/claims.go
+++ b/internal/core/machine/claims.go
@@ -161,13 +161,30 @@ const propertyDefaultRoute = "the default route"
 // Who may claim the default route, and why a public address claims it with no
 // value beside it. A machine holding a public address has a way out already:
 // on the routed shape RouteAddress lays it, and on the shape where the address
-// rides a managed NIC the network's own router carries it. Which door a reply
-// leaves by on each shape is a MEASUREMENT, not a deduction, and one of the two
-// shapes has never been measured (#672). So the public address is registered
-// as the route's owner — which is what refuses a second owner — and no claim
-// states its value. Silence, not a guess: a verifier that invented its expected
-// values would be a second reconciler, wrong with the same confidence as the
-// first.
+// rides a managed NIC the network's own router carries it.
+//
+// Which door a reply leaves by is a MEASUREMENT, not a deduction, and it has
+// been made: four readings, both modes, both orders of construction, in
+// docs/limits.md under "Which door a reply leaves by, and why it does not
+// decide" (#672). The result is why the silence below is now a finding rather
+// than a gap.
+//
+//	mode        door: ip route get <peer> from <public>   station reaches it
+//	incus-ovn   dev ethN, on-link, no via                 no
+//	incus       dev ethN, on-link, no via                 yes
+//
+// The door reads the SAME on a machine the station reaches and on one it does
+// not, so a claim comparing Via and Dev — which is what door.Check compares —
+// would report `held` about a machine that answers nobody. What differs is the
+// peer, not the door: a published address is reached through the uplink, and
+// the address the station answers from is on the guest's subnet under a bridge
+// and off it under OVN, where the ARP for it goes unanswered.
+//
+// So the public address is registered as the route's owner — which is what
+// refuses a second owner — and no claim states its value. Silence, not a
+// guess: a verifier that invented its expected values would be a second
+// reconciler, wrong with the same confidence as the first, and one that
+// derived them from the table above would certify an unreachable machine.
 //
 // TestAPlanWithTwoClaimantsToTheDefaultRouteIsRefusedBeforeTheRuntimeIsAsked
 // fails without the refusal, and TestAPublicAddressAloneClaimsNoValueForTheDefaultRoute
@@ -483,8 +500,12 @@ func prefixes(blocks []netip.Prefix) string {
 // door claims which door a reply sent from an address leaves by, towards a
 // destination: the answer to `ip route get <To> from <From>`, compared on
 // `via` and `dev` alone. The comparator exists for the reading half (#668);
-// nothing derives a door claim yet, because the value is a measurement per
-// machine shape and one of the two shapes has none (#672).
+// nothing derives a door claim, and #672 measured why rather than leaving it
+// open: on the shape where the address rides a managed NIC, the door reads
+// `dev ethN` on-link with no `via` BOTH when the station reaches the machine
+// (bridge) and when it does not (OVN). Comparing `via` and `dev` therefore
+// cannot tell those two apart, and a derived claim would report `held` about a
+// machine that answers nobody. docs/limits.md carries the four readings.
 type door struct {
 	From, To netip.Addr
 	Via      netip.Addr

--- a/internal/core/machine/readback_test.go
+++ b/internal/core/machine/readback_test.go
@@ -194,9 +194,11 @@ func TestObserveNamesAVirtualMachinesInterfacesByMAC(t *testing.T) {
 // doors named.
 //
 // The wanted door is the TEST's, written down as what docs/limits.md records
-// for the routed shape, and deliberately not derived: which door is right on
-// the shape this fixture models is the measurement #672 asks for, and this
-// test holds the comparator, not the table.
+// for the routed shape, and deliberately not derived. #672 has since measured
+// the shape this fixture models, and the measurement is the reason to keep it
+// that way: the door reads the same on a reachable machine and an unreachable
+// one, so a derived value would certify the wrong thing. This test holds the
+// comparator, and there is no table to hold.
 func TestTheReplyDoorOfTheRegressionIsBroken(t *testing.T) {
 	f := &fakeRuntime{}
 	regressionMachine(f)


### PR DESCRIPTION
#672 asked for one thing before any mechanism: measure which door a reply
leaves by, per machine shape, because a verifier that invented its expected
values would be a second reconciler, wrong with the same confidence as the
first. Four readings, 2026-09-07, both `--vm` modes and both orders of
construction.

THE ANSWER IS THAT THE DOOR DOES NOT DECIDE.

    mode        order              door                        neighbour     reached
    incus-ovn   address, NIC hot   dev eth1, on-link, no via   INCOMPLETE    no
    incus-ovn   NIC cold, address  dev eth0, on-link, no via   INCOMPLETE    no
    incus       address, NIC hot   dev eth1, on-link, no via   DELAY         yes
    incus       NIC cold, address  dev eth0, on-link, no via   REACHABLE     yes

The door reads identically on a machine the station reaches and on one it does
not. `machine.door.Check` compares `via` and `dev` alone, so a claim derived
from this table would report `held` about a machine that answers nobody. That
is why the silence in claims.go stays, and it is now silence for a measured
reason rather than for an unmeasured one — which is a stronger thing to be able
to say.

WHAT DIFFERS IS THE PEER, WHICH IS WHERE NOBODY WAS LOOKING.

A published address is reached through the uplink, so the address the station
answers from is not its LAN address:

    --vm incus-ovn   203.0.113.2 dev feint-uplink src 10.209.83.1
    --vm incus       203.0.113.2 via 10.211.0.2 dev fnt-943… src 10.211.0.1

The guest replies to the uplink's own address under OVN, and to the bridge's
gateway under a bridge. Its route to either is on-link, so it resolves the peer
itself, and only one of the two is on its subnet:

    --vm incus-ovn   10.209.83.1 dev eth1  INCOMPLETE     nobody answers the ARP
    --vm incus       10.211.0.1  dev eth0  REACHABLE

The request lands either way — one connection in SYN_RECV inside the guest
while the station dials, under OVN — so nothing inbound is dropped. It is the
reply that never reaches the wire. That settles #672's own open question,
verbatim: "Same gateway, same device, opposite results. Which means the door is
not the whole story in shape B, and nobody has established what is."

The on-link route is DHCP's — `10.209.83.1 dev eth1 proto dhcp scope link`.
systemd-networkd lays an on-link /32 towards every DNS server a lease announces
(RoutesToDNS=), the OVN network announces the uplink as its resolver, and a /32
beats any default route by longest prefix. Same family as #660 and #694.

AND ONE THING docs/limits.md SAID IS MODE-SPECIFIC.

It has described the routed shape as keeping `default via 169.254.0.1` even
when a private NIC arrives later. That holds under a bridge, where the reading
shows both defaults side by side and the routed interface carrying the way out.
Under OVN the routed device exists — nictype routed, ipv4.host_address
169.254.0.1 — and carries no address at all in the guest, so it lays no default
route, the address rides the managed NIC as ipv4.routes.external, and
`ip route get 1.1.1.1` answers "Network is unreachable". That is #695's
outbound half, and its cause is now recorded rather than suspected.

INSTRUMENT, BECAUSE THE ISSUE MADE IT A CONDITION.

The listening proof is functionallib.sh's — /proc/net/tcp state 0A, not `ss`
and not /dev/tcp — and fnl_listen_reader_control runs against a planted witness
before any verdict. It earned its place twice: the harness first failed that
control by not supplying the `fail` the library expects from its caller, and
then a 20 s curl budget killed the emulator's runtime calls mid-flight
(`incus config: signal: killed`), so the first run measured this harness's
patience rather than a machine.

WHAT IS NOT HERE. No door claim is derived — the measurement is the reason not
to, and #672 says the fix follows the measurement rather than preceding it.
Nothing about what the real cloud answers: no recording carries it, and the
section says so.

Closes #672

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Checks

- `mise run prepush` exits 0
- The four readings come from a fixture driven under `FEINT_VM=incus-ovn` and `FEINT_VM=incus`, one emulator per mode, cleaned up after each run; the station holds no feint instance or network afterwards
- `docs:coverage` regenerated the safety banner (55 → 56 sections)

## What this hands #695

Its cause, measured: under OVN the routed NIC carries no address, so there is no default route at all and `ip route get 1.1.1.1` is unreachable; and the reply to the station dies on an ARP for an address off the guest's subnet. Whatever the fix is, it has to keep the bridge mode working, which this table now pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
