### PR TITLE
fix(core): a value a client controls cannot forge a line in the emulator's log

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ internal/core/network/      address plans, subnets, firewall bindings
 internal/core/cloudinit/    the boot payload a provider hands its machines
 internal/core/serialise/    keyed mutual exclusion: one lock per named target
 internal/core/sshkey/       the OpenSSH one-line public key format, read and refused
+internal/core/logline/      a value a client controls, spelled as one line for the log
 internal/contract/          API descriptions, and the check that answers match them
 internal/corpus/            turns a recording of a real cloud into an artefact this repository
                             may commit: values synthetic, statuses and order kept

--- a/internal/core/logline/logline.go
+++ b/internal/core/logline/logline.go
@@ -1,0 +1,96 @@
+// Package logline spells a value a client controls as one printable line, so
+// that the emulator's log records what happened and never what the value
+// pretended.
+//
+// The values are the ones CLAUDE.md names as inputs from outside however
+// internal they look: a machine or network name restored verbatim from a
+// snapshot (Resource.Runtime), an image identifier a request carried, an
+// address a pack was asked to route, the host a CONNECT named, and the error a
+// driver built out of any of them. Written raw into a log record, a newline in
+// one of them ends the record and starts another that reads as the emulator's
+// own — CWE-117, which CodeQL reported fifteen times over binding.go, plan.go
+// and forward.go, read live on 2026-09-06.
+//
+// Two neighbours do related work and neither is this one. cloudinit's
+// Spec.checkInjection refuses a control character at the door, because its
+// value is rendered into a YAML document where no spelling of it is safe. A
+// log is different: the value being written is often the one the emulator
+// just refused, and an operator has to read what was refused — so it is
+// spelled, not dropped. internal/cli's TestALoggedClientValueCannotForgeALine
+// measures that slog.TextHandler already quotes such a value at the sink;
+// Sanitise puts the property on the value instead, so it holds whatever
+// handler an operator plugs in, and so the analysis that reported the flow can
+// measure it cut rather than be asked to believe a dismissal.
+//
+// It sits under internal/core because both the machine layer and the proxy
+// need it and neither may import the other; it imports nothing but the
+// standard library, so it can never close a cycle, and it names no provider.
+package logline
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Sanitise returns s with every character that cannot stand in a printable
+// line spelled the way a Go string literal spells it: a newline as the two
+// characters `\n`, an escape as `\x1b`, a Unicode line separator as `\u2028`,
+// a byte that is not UTF-8 as `\xff`. A value made of printable characters —
+// every machine name, image identifier, address and host this emulator handles
+// — comes back unchanged, and that half is measured too: a sanitiser that
+// refuses everything passes every attack and breaks the product.
+//
+// The loop is the sanitiser: every C0 and C1 control, the escape that drives
+// a terminal, DEL, the separators U+2028 and U+2029, the spaces that are not
+// the ASCII one, and a byte that is not UTF-8. The two strings.ReplaceAll
+// calls before it are redundant with it by design — the loop would spell a
+// newline just as well — and they stay because they are the exact shape
+// CodeQL's go/log-injection query recognises as a sanitiser (a ReplaceAll
+// whose replaced string is "\n" or "\r"), so the flow is measured as cut by
+// the instrument that reported it, on every pull request, instead of
+// dismissed in a web page nobody re-reads. That run is what holds them and
+// nothing local can: removing either changes nothing the loop does not repair,
+// which tools/falsify/specs/a-log-line-cannot-be-forged.json found on its
+// first attempt ("test still passed") and is why it declares no mutation on
+// them.
+//
+// TestSanitiseSpellsEveryControlCharacter fails without the loop's spelling,
+// and TestSanitiseLeavesAPrintableValueAlone without the other half.
+func Sanitise(s string) string {
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	if utf8.ValidString(s) && strings.IndexFunc(s, unprintable) < 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case r == utf8.RuneError && size == 1:
+			// Not UTF-8 at all, so no rune stands for it: spell the byte.
+			b.WriteString(spell(s[i : i+1]))
+		case unprintable(r):
+			b.WriteString(spell(s[i : i+size]))
+		default:
+			b.WriteString(s[i : i+size])
+		}
+		i += size
+	}
+	return b.String()
+}
+
+// unprintable is what cannot stand in a line as itself. unicode.IsPrint keeps
+// letters, marks, numbers, punctuation, symbols and the ASCII space, which is
+// every character a legitimate name carries; what it refuses is every control
+// character, the other spaces (a tab, a no-break space) and the separators.
+func unprintable(r rune) bool { return !unicode.IsPrint(r) }
+
+// spell is Go's own spelling of one character, without the quotes strconv puts
+// around it: `\t`, `\x1b`, `\u2028`, and `\xff` for a byte that is not UTF-8.
+func spell(fragment string) string {
+	q := strconv.Quote(fragment)
+	return q[1 : len(q)-1]
+}

--- a/internal/core/logline/logline_test.go
+++ b/internal/core/logline/logline_test.go
@@ -70,9 +70,9 @@ func TestSanitiseSpellsEveryControlCharacter(t *testing.T) {
 func TestSanitiseLeavesAPrintableValueAlone(t *testing.T) {
 	for _, name := range []string{
 		"",
-		"feint-scw-8f3a2b1c-77d2-4a6e-9b0e-1c2d3e4f5a6b",
+		"feint-acme-8f3a2b1c-77d2-4a6e-9b0e-1c2d3e4f5a6b",
 		"fnt-ovn-9b0e1c2d",
-		"api-ch-gva-2.exoscale.com:443",
+		"api-eu-west-1.example.net:443",
 		"ami-47899c77",
 		"ubuntu_24.04",
 		"Ubuntu 24.04 LTS (noble)",

--- a/internal/core/logline/logline_test.go
+++ b/internal/core/logline/logline_test.go
@@ -1,0 +1,89 @@
+package logline_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stephrobert/feint/internal/core/logline"
+)
+
+// The refusing half: every character that could end a record or drive a
+// terminal comes out spelled, and the result is a printable line.
+func TestSanitiseSpellsEveryControlCharacter(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"a newline", "a\nb", `a\nb`},
+		{"a carriage return", "a\rb", `a\rb`},
+		{"the CRLF pair", "a\r\nb", `a\r\nb`},
+		{"a terminal escape", "a\x1b[2Kb", `a\x1b[2Kb`},
+		{"a NUL", "a\x00b", `a\x00b`},
+		{"a backspace", "a\bb", `a\bb`},
+		{"DEL", "a\x7fb", `a\x7fb`},
+		{"a tab", "a\tb", `a\tb`},
+		{"a C1 control", "a\u0085b", `a\u0085b`},
+		{"the line separator", "a\u2028b", `a\u2028b`},
+		{"the paragraph separator", "a\u2029b", `a\u2029b`},
+		{"a byte that is not UTF-8", "a\xffb", `a\xffb`},
+		{"a newline behind a byte that is not UTF-8", "a\xff\nb", `a\xff\nb`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := logline.Sanitise(c.in)
+			if got != c.want {
+				t.Errorf("Sanitise(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("Sanitise(%q) = %q is not UTF-8", c.in, got)
+			}
+			if i := strings.IndexFunc(got, func(r rune) bool { return !unicode.IsPrint(r) }); i >= 0 {
+				t.Errorf("Sanitise(%q) = %q still carries an unprintable character at %d", c.in, got, i)
+			}
+		})
+	}
+
+	// The payload an injection uses — end the record, start one that reads as
+	// the emulator's own — through a writer that quotes nothing. The property
+	// is on the value, so the handler does not have to help.
+	t.Run("a forged record through a writer that does not quote", func(t *testing.T) {
+		forged := "203.0.113.9\nlevel=ERROR msg=\"the emulator was compromised\" attacker=yes"
+		var out bytes.Buffer
+		fmt.Fprintf(&out, "level=WARN msg=refused address=%s\n", logline.Sanitise(forged))
+		written := out.String()
+		if n := strings.Count(written, "\n"); n != 1 {
+			t.Errorf("one record produced %d line(s): the value ended it and started another\n%s", n, written)
+		}
+		if strings.Contains(written, "\nlevel=ERROR") {
+			t.Errorf("the forged record stands on a line of its own:\n%s", written)
+		}
+		if !strings.Contains(written, "203.0.113.9") {
+			t.Errorf("the refused address is not in the record at all:\n%s", written)
+		}
+	})
+}
+
+// The accepting half, and the one a sanitiser is most often written without:
+// what this emulator actually logs — machine names, hosts, image identifiers,
+// addresses, an error the runtime returned — comes back byte for byte.
+func TestSanitiseLeavesAPrintableValueAlone(t *testing.T) {
+	for _, name := range []string{
+		"",
+		"feint-scw-8f3a2b1c-77d2-4a6e-9b0e-1c2d3e4f5a6b",
+		"fnt-ovn-9b0e1c2d",
+		"api-ch-gva-2.exoscale.com:443",
+		"ami-47899c77",
+		"ubuntu_24.04",
+		"Ubuntu 24.04 LTS (noble)",
+		"203.0.113.9",
+		"fe80::1%eth0",
+		"la machine d'Éliane, n° 3",
+		"incus launch: Error: Failed getting remote image info",
+		`a literal backslash \n stays the two characters it is`,
+	} {
+		if got := logline.Sanitise(name); got != name {
+			t.Errorf("Sanitise(%q) = %q: a printable value must come back unchanged", name, got)
+		}
+	}
+}

--- a/internal/core/machine/binding.go
+++ b/internal/core/machine/binding.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stephrobert/feint/internal/core/cloudinit"
+	"github.com/stephrobert/feint/internal/core/logline"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -262,8 +263,17 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 			b.refuseUnknownImage(boot)
 			return Started{}
 		}
+		// Every value a client controls that this file writes into a log
+		// record goes through logline.Sanitise — the identifier a request
+		// named, here and in the two refusals below, and the error the driver
+		// built out of what it was handed — so a newline in it cannot end the
+		// record and start one that reads as the emulator's own (CodeQL
+		// go/log-injection, alerts 40-44 and 60). The name is not ours either
+		// when it looks like it: "well formed is not authorised" in CLAUDE.md
+		// says why a restored value is an input. TestNoClientValueForgesALineInTheBootLog
+		// fails without any one of these calls.
 		b.logger().Info("booting the image the operator declared for this identifier",
-			"provider", b.Provider, "resource", boot.ID, "image", boot.Requested,
+			"provider", b.Provider, "resource", boot.ID, "image", logline.Sanitise(boot.Requested),
 			"declared", declared.Ref, "via", "FEINT_BOOT_IMAGES")
 		boot.Image = declared.Ref
 		// The login rides the image here as everywhere else: on the cloud where
@@ -289,7 +299,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 			spec, _ := SpecFor(boot.Image)
 			b.logger().Error("refusing to boot: the image this reference derives could not be built",
 				"provider", b.Provider, "resource", boot.ID, "image", boot.Image,
-				"requested", boot.Requested, "source", spec.Source, "error", err,
+				"requested", logline.Sanitise(boot.Requested), "source", spec.Source, "error", err,
 				"fix", "`feint images --only "+spec.Name+"` reproduces the build by hand; "+
 					"a version the upstream image server no longer publishes cannot be built — name one it does")
 			return Started{}
@@ -364,7 +374,7 @@ func (b Binding) Start(ctx context.Context, boot Boot) Started {
 		// to learn why nothing started.
 		b.logger().Error("could not start the backing machine",
 			"provider", b.Provider, "resource", boot.ID,
-			"machine", name, "image", boot.Image, "error", err)
+			"machine", name, "image", boot.Image, "error", logline.Sanitise(err.Error()))
 		return Started{}
 	}
 	return Started{Machine: name, Addresses: m.Addresses}
@@ -414,7 +424,11 @@ func (b Binding) refuseUnknownImage(boot Boot) {
 	if reason == "" {
 		reason = "the identifier is in no catalogue"
 	}
-	id := boot.Requested
+	// Spelled once, and every attribute below reads the spelling: the
+	// identifier is the client's, verbatim. See Start's note on
+	// logline.Sanitise; TestNoClientValueForgesALineInTheBootLog fails
+	// without this.
+	id := logline.Sanitise(boot.Requested)
 	if id == "" {
 		id = "<empty>"
 	}

--- a/internal/core/machine/loginjection_test.go
+++ b/internal/core/machine/loginjection_test.go
@@ -1,0 +1,210 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+
+	"github.com/stephrobert/feint/internal/core/resource"
+)
+
+// A value a client controls cannot forge a line in the machine layer's log.
+//
+// CodeQL reported go/log-injection thirteen times over binding.go and plan.go
+// (alerts 40-44, 51-53 and 56-60, read live on 2026-09-06), and every one of
+// them is a real flow: the image identifier a request carried, the address a
+// pack asked to route, the address a membership carries, and the error a
+// driver built out of one of those. None of them is a value of ours, however
+// internal it looks — "well formed is not authorised" in CLAUDE.md: Runtime and
+// Attrs are restored verbatim by PUT /_feint/state, and a snapshot is designed
+// to travel.
+//
+// What is measured is what the layer hands to the logger, read through
+// ReplaceAttr before the handler spells it. That choice is the whole test:
+// slog.TextHandler quotes a newline on its own (internal/cli's
+// TestALoggedClientValueCannotForgeALine measured it), so a test reading the
+// handler's output would stay green with every sanitiser removed. The property
+// this repository wants is on the value — one line, whatever handler an
+// operator plugs in — and logline.Sanitise is what puts it there.
+//
+// tools/falsify/specs/a-log-line-cannot-be-forged.json removes each call in
+// turn and requires the matching test here to go red.
+
+// forgedLine is the payload an injection uses: end the record, start one that
+// reads as the emulator's own. "evil" is the part a reader must still see.
+const forgedLine = "evil\nlevel=ERROR msg=\"the emulator was compromised\" attacker=yes"
+
+// recordedLogger reads every attribute as the layer wrote it, before the
+// handler spells it.
+func recordedLogger() (*slog.Logger, func() []slog.Attr) {
+	var mu sync.Mutex
+	var seen []slog.Attr
+	h := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, a)
+			return a
+		},
+	})
+	return slog.New(h), func() []slog.Attr {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]slog.Attr(nil), seen...)
+	}
+}
+
+// assertOneLine requires every attribute handed to the logger to stand on one
+// line, and the readable part of the payload to be in one of them: a value
+// that was hidden rather than spelled would pass the first half and fail the
+// second, which is the difference between sanitising and censoring.
+func assertOneLine(t *testing.T, attrs []slog.Attr, readable string) {
+	t.Helper()
+	if len(attrs) == 0 {
+		t.Fatal("nothing was logged, so nothing was measured")
+	}
+	seen := false
+	for _, a := range attrs {
+		v := a.Value.String()
+		if i := strings.IndexFunc(v, unicode.IsControl); i >= 0 {
+			t.Errorf("attribute %s reached the logger carrying a control character at %d: a handler "+
+				"that does not quote writes it as a record of its own\n%s=%q", a.Key, i, a.Key, v)
+		}
+		if strings.Contains(v, readable) {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Errorf("no attribute carries %q: the value was hidden where an operator needs to read it", readable)
+	}
+}
+
+// forgingDriver answers the way a real runtime does when it fails: with an
+// error that repeats what it was handed, over several lines — incus prints
+// its stderr into the error, and the name or the address in it is the
+// client's.
+type forgingDriver struct {
+	recordingDriver
+	startErr, routeErr, unrouteErr, attachErr error
+}
+
+func (d *forgingDriver) Start(ctx context.Context, spec Spec) (Machine, error) {
+	if d.startErr != nil {
+		return Machine{}, d.startErr
+	}
+	return d.recordingDriver.Start(ctx, spec)
+}
+
+func (d *forgingDriver) Attach(context.Context, string, Attachment) error { return d.attachErr }
+
+func (d *forgingDriver) RouteAddress(context.Context, AddressSpec) error { return d.routeErr }
+
+func (d *forgingDriver) UnrouteAddress(context.Context, string, string) error {
+	return d.unrouteErr
+}
+
+func TestNoClientValueForgesALineInTheBootLog(t *testing.T) {
+	ctx := context.Background()
+	keys := []string{"ssh-ed25519 AAAA test"}
+
+	t.Run("the identifier a refusal names", func(t *testing.T) {
+		log, attrs := recordedLogger()
+		b := bootBinding(&recordingDriver{})
+		b.Log = log
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+		if b.PowerOn(ctx, res, Boot{Requested: forgedLine}) {
+			t.Fatal("a boot with no resolved image reported success")
+		}
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the identifier a declaration resolved", func(t *testing.T) {
+		log, attrs := recordedLogger()
+		b := bootBinding(&recordingDriver{})
+		b.Log = log
+		b.Declared = map[string]Image{forgedLine: {Ref: "ubuntu:24.04"}}
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+		if !b.PowerOn(ctx, res, Boot{Requested: forgedLine, AuthorizedKeys: keys}) {
+			t.Fatal("the declared image did not boot")
+		}
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the identifier a failed build names", func(t *testing.T) {
+		log, attrs := recordedLogger()
+		b := bootBinding(&buildingDriver{fail: errors.New("Failed getting remote image info")})
+		b.Log = log
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+		if b.PowerOn(ctx, res, Boot{Image: "debian:9", Requested: forgedLine, AuthorizedKeys: keys}) {
+			t.Fatal("a boot whose build failed reported success")
+		}
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the error a failed start carries", func(t *testing.T) {
+		log, attrs := recordedLogger()
+		b := bootBinding(&forgingDriver{startErr: errors.New("incus launch: " + forgedLine)})
+		b.Log = log
+		res := &resource.Resource{ID: "srv-1", State: "stopped"}
+		if b.PowerOn(ctx, res, Boot{Image: "ubuntu:24.04", Requested: "ubuntu", AuthorizedKeys: keys}) {
+			t.Fatal("a start the runtime refused reported success")
+		}
+		assertOneLine(t, attrs(), "evil")
+	})
+}
+
+func TestNoClientValueForgesALineInTheAddressLog(t *testing.T) {
+	ctx := context.Background()
+	bench := func(d *forgingDriver) (Reconciler, func() []slog.Attr, *resource.Resource) {
+		log, attrs := recordedLogger()
+		b := bootBinding(d)
+		b.Log = log
+		r := Reconciler{
+			Groups:      GroupSync{Binding: b},
+			PlanOf:      func(*resource.Resource) Plan { return Plan{} },
+			PublicBlock: netip.MustParsePrefix("203.0.113.0/24"),
+		}
+		res := &resource.Resource{
+			ID:      "srv-1",
+			State:   "running",
+			Runtime: map[string]string{"machine": "feint-acme-srv-1"},
+		}
+		return r, attrs, res
+	}
+
+	// The three log calls are reached directly rather than through the
+	// choreography around them: what is under test is the argument of the
+	// call, and the order of the replay has its own witnesses in plan_test.go.
+	t.Run("the address a route refuses", func(t *testing.T) {
+		r, attrs, res := bench(&forgingDriver{})
+		r.route(ctx, res, Plan{}, forgedLine)
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the error a route failure carries", func(t *testing.T) {
+		r, attrs, res := bench(&forgingDriver{routeErr: errors.New("incus: " + forgedLine)})
+		r.route(ctx, res, Plan{}, "203.0.113.9")
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the error an unroute failure carries", func(t *testing.T) {
+		r, attrs, _ := bench(&forgingDriver{unrouteErr: errors.New("incus: " + forgedLine)})
+		r.Unroute(ctx, "feint-acme-srv-1", "203.0.113.9")
+		assertOneLine(t, attrs(), "evil")
+	})
+
+	t.Run("the address and the error an attach failure carries", func(t *testing.T) {
+		r, attrs, res := bench(&forgingDriver{attachErr: errors.New("incus: " + forgedLine)})
+		if err := r.attach(ctx, res, Attachment{Network: "fnt-acme-net", Address: forgedLine}); err == nil {
+			t.Fatal("an attach the runtime refused reported success")
+		}
+		assertOneLine(t, attrs(), "evil")
+	})
+}

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strings"
 
+	"github.com/stephrobert/feint/internal/core/logline"
 	"github.com/stephrobert/feint/internal/core/resource"
 )
 
@@ -425,9 +426,19 @@ func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan
 	if name == "" || address == "" {
 		return
 	}
+	// The address is the pack's caller's, and the error is what the driver
+	// built out of it and of the machine's stored name: every one of them is
+	// spelled through logline.Sanitise on its way into a log record, here, in
+	// Unroute and in attach, so a newline in it cannot end the record and
+	// start one that reads as the emulator's own (CodeQL go/log-injection,
+	// alerts 51-53 and 56-59). TestNoClientValueForgesALineInTheAddressLog
+	// fails without the calls a test can reach; the address below the
+	// refusal has passed netip.ParseAddr and Prefix.Contains, so no test can
+	// put a control character in it, and its two calls exist for the reader
+	// and the analysis, not as guards — tools/falsify/specs says so too.
 	if !r.emulated(address) {
 		r.binding().logger().Warn("refusing to route an address outside the emulated public block",
-			"provider", r.binding().Provider, "address", address, "resource", res.ID)
+			"provider", r.binding().Provider, "address", logline.Sanitise(address), "resource", res.ID)
 		return
 	}
 	if err := r.binding().RouteAddress(ctx, router, AddressSpec{
@@ -436,7 +447,7 @@ func (r Reconciler) route(ctx context.Context, res *resource.Resource, plan Plan
 		Network: plan.RouteVia,
 	}); err != nil {
 		r.binding().logger().Error("could not route the public address to the machine",
-			"provider", r.binding().Provider, "address", address, "resource", res.ID, "error", err)
+			"provider", r.binding().Provider, "address", logline.Sanitise(address), "resource", res.ID, "error", logline.Sanitise(err.Error()))
 	}
 }
 
@@ -451,7 +462,7 @@ func (r Reconciler) Unroute(ctx context.Context, machine, address string) {
 	}
 	if err := r.binding().UnrouteAddress(ctx, router, machine, address); err != nil {
 		r.binding().logger().Error("could not stop routing the public address",
-			"provider", r.binding().Provider, "address", address, "error", err)
+			"provider", r.binding().Provider, "address", logline.Sanitise(address), "error", logline.Sanitise(err.Error()))
 	}
 }
 
@@ -588,7 +599,7 @@ func (r Reconciler) attach(ctx context.Context, res *resource.Resource, att Atta
 	if err := driver.Attach(ctx, name, att); err != nil {
 		r.binding().logger().Error("could not attach the machine to the network",
 			"provider", r.binding().Provider, "resource", res.ID, "network", att.Network,
-			"address", att.Address, "error", err)
+			"address", logline.Sanitise(att.Address), "error", logline.Sanitise(err.Error()))
 		return err
 	}
 	return nil

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -53,6 +53,7 @@ import (
 	"time"
 
 	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/logline"
 )
 
 // tunnelHandshakeTimeout bounds the TLS handshake of one accepted tunnel.
@@ -457,9 +458,16 @@ func (f *Forward) patterns() []string {
 // TestARefusalNamesTheEntryThatIsMissing fails without it.
 func (f *Forward) refuse(w http.ResponseWriter, host string) {
 	f.refused.note(host)
+	// The host is the client's, off its CONNECT line, and it is written into
+	// a log record: spelled as one line so it cannot end the record and start
+	// one that reads as the proxy's own (CodeQL go/log-injection, alerts 35
+	// and 36). net/http refuses a malformed Host before it reaches here, which
+	// makes this the second wall rather than the first — and the one the
+	// analysis can see. TestARefusedHostCannotForgeALogLine fails without it.
+	shown := logline.Sanitise(host)
 	f.log.Warn("refused to intercept a host --forward does not name",
-		"host", host, "forwarding", strings.Join(f.patterns(), ", "),
-		"add", host+" (to the real host), or "+host+"=<target> to send it somewhere you choose")
+		"host", shown, "forwarding", strings.Join(f.patterns(), ", "),
+		"add", shown+" (to the real host), or "+shown+"=<target> to send it somewhere you choose")
 	http.Error(w, missingEntry(host), http.StatusForbidden)
 }
 

--- a/internal/proxy/refuse_internal_test.go
+++ b/internal/proxy/refuse_internal_test.go
@@ -1,0 +1,59 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+)
+
+// A host a client named cannot forge a line in the proxy's log.
+//
+// CodeQL reported go/log-injection twice on refuse (alerts 35 and 36, read
+// live on 2026-09-06): the host off the CONNECT line reaches the record, and
+// so does the recipe built around it. net/http refuses a malformed Host before
+// the handler runs, so this is the second wall; it is measured here at the
+// value the proxy hands to the logger, read through ReplaceAttr before the
+// handler quotes it — slog.TextHandler would quote a newline on its own and a
+// test reading its output would stay green with the sanitiser removed.
+// tools/falsify/specs/a-log-line-cannot-be-forged.json removes the call and
+// requires this test to go red.
+func TestARefusedHostCannotForgeALogLine(t *testing.T) {
+	var mu sync.Mutex
+	var seen []slog.Attr
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, a)
+			return a
+		},
+	}))
+	f := &Forward{log: log}
+
+	forged := "evil.example\nlevel=ERROR msg=\"the proxy was compromised\" attacker=yes"
+	f.refuse(httptest.NewRecorder(), forged)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) == 0 {
+		t.Fatal("nothing was logged, so nothing was measured")
+	}
+	readable := false
+	for _, a := range seen {
+		v := a.Value.String()
+		if i := strings.IndexFunc(v, unicode.IsControl); i >= 0 {
+			t.Errorf("attribute %s reached the logger carrying a control character at %d: a handler "+
+				"that does not quote writes it as a record of its own\n%s=%q", a.Key, i, a.Key, v)
+		}
+		if strings.Contains(v, "evil.example") {
+			readable = true
+		}
+	}
+	if !readable {
+		t.Error("no attribute names evil.example: the host was hidden where an operator needs to read it")
+	}
+}

--- a/tools/falsify/specs/a-log-line-cannot-be-forged.json
+++ b/tools/falsify/specs/a-log-line-cannot-be-forged.json
@@ -1,0 +1,84 @@
+{
+  "package": "./internal/core/machine/",
+  "mutations": [
+    {
+      "label": "an unprintable character is written as itself, so an escape sequence drives the terminal again; the two strings.ReplaceAll calls above the loop are not mutated, since the loop repairs whatever they miss and only the CodeQL run on a pull request measures them",
+      "file": "internal/core/logline/logline.go",
+      "find": "\t\tcase unprintable(r):",
+      "replace": "\t\tcase unprintable(r) && false:",
+      "test": "TestSanitiseSpellsEveryControlCharacter",
+      "package": "./internal/core/logline/"
+    },
+    {
+      "label": "the identifier a declaration resolved reaches the boot log raw",
+      "file": "internal/core/machine/binding.go",
+      "find": "\"resource\", boot.ID, \"image\", logline.Sanitise(boot.Requested),",
+      "replace": "\"resource\", boot.ID, \"image\", logline.Sanitise(\"\")+boot.Requested,",
+      "test": "TestNoClientValueForgesALineInTheBootLog"
+    },
+    {
+      "label": "the identifier a failed build names reaches the boot log raw",
+      "file": "internal/core/machine/binding.go",
+      "find": "\"requested\", logline.Sanitise(boot.Requested), \"source\", spec.Source,",
+      "replace": "\"requested\", logline.Sanitise(\"\")+boot.Requested, \"source\", spec.Source,",
+      "test": "TestNoClientValueForgesALineInTheBootLog"
+    },
+    {
+      "label": "the error a failed start carries reaches the boot log raw",
+      "file": "internal/core/machine/binding.go",
+      "find": "\"machine\", name, \"image\", boot.Image, \"error\", logline.Sanitise(err.Error()))",
+      "replace": "\"machine\", name, \"image\", boot.Image, \"error\", logline.Sanitise(\"\")+err.Error())",
+      "test": "TestNoClientValueForgesALineInTheBootLog"
+    },
+    {
+      "label": "the identifier a refusal names reaches its three attributes raw",
+      "file": "internal/core/machine/binding.go",
+      "find": "\tid := logline.Sanitise(boot.Requested)",
+      "replace": "\tid := logline.Sanitise(\"\") + boot.Requested",
+      "test": "TestNoClientValueForgesALineInTheBootLog"
+    },
+    {
+      "label": "the address a route refuses reaches the log raw",
+      "file": "internal/core/machine/plan.go",
+      "find": "\"address\", logline.Sanitise(address), \"resource\", res.ID)",
+      "replace": "\"address\", logline.Sanitise(\"\")+address, \"resource\", res.ID)",
+      "test": "TestNoClientValueForgesALineInTheAddressLog"
+    },
+    {
+      "label": "the error a route failure carries reaches the log raw; the address beside it has passed netip.ParseAddr and Prefix.Contains, so no mutation of its call can bite and none is declared",
+      "file": "internal/core/machine/plan.go",
+      "find": "\"address\", logline.Sanitise(address), \"resource\", res.ID, \"error\", logline.Sanitise(err.Error()))",
+      "replace": "\"address\", logline.Sanitise(address), \"resource\", res.ID, \"error\", logline.Sanitise(\"\")+err.Error())",
+      "test": "TestNoClientValueForgesALineInTheAddressLog"
+    },
+    {
+      "label": "the error an unroute failure carries reaches the log raw; same remark on the address beside it",
+      "file": "internal/core/machine/plan.go",
+      "find": "\"address\", logline.Sanitise(address), \"error\", logline.Sanitise(err.Error()))",
+      "replace": "\"address\", logline.Sanitise(address), \"error\", logline.Sanitise(\"\")+err.Error())",
+      "test": "TestNoClientValueForgesALineInTheAddressLog"
+    },
+    {
+      "label": "the address an attach failure carries reaches the log raw",
+      "file": "internal/core/machine/plan.go",
+      "find": "\"address\", logline.Sanitise(att.Address), \"error\", logline.Sanitise(err.Error()))",
+      "replace": "\"address\", logline.Sanitise(\"\")+att.Address, \"error\", logline.Sanitise(err.Error()))",
+      "test": "TestNoClientValueForgesALineInTheAddressLog"
+    },
+    {
+      "label": "the error an attach failure carries reaches the log raw",
+      "file": "internal/core/machine/plan.go",
+      "find": "\"address\", logline.Sanitise(att.Address), \"error\", logline.Sanitise(err.Error()))",
+      "replace": "\"address\", logline.Sanitise(att.Address), \"error\", logline.Sanitise(\"\")+err.Error())",
+      "test": "TestNoClientValueForgesALineInTheAddressLog"
+    },
+    {
+      "label": "the host a refusal names reaches the proxy's log raw, in both attributes",
+      "file": "internal/proxy/forward.go",
+      "find": "\tshown := logline.Sanitise(host)",
+      "replace": "\tshown := logline.Sanitise(\"\") + host",
+      "test": "TestARefusedHostCannotForgeALogLine",
+      "package": "./internal/proxy/"
+    }
+  ]
+}

--- a/tools/testplan/rules.go
+++ b/tools/testplan/rules.go
@@ -322,6 +322,12 @@ var rules = []rule{
 		}},
 	},
 	{
+		Path:     "internal/core/logline/",
+		Why:      "how a value a client controls is spelled into the emulator's log",
+		Runs:     nil,
+		Unproven: prepushIsTheWholeGate,
+	},
+	{
 		Path:     "internal/proxy/",
 		Why:      "the recording proxy that captured the real clouds",
 		Runs:     []string{"corpus:check"},


### PR DESCRIPTION
# Summary

Closes the fifteen open `go/log-injection` (CWE-117) code-scanning alerts by
correction, not dismissal: 40-44 and 60 on `internal/core/machine/binding.go`,
51-53 and 56-59 on `internal/core/machine/plan.go`, 35 and 36 on
`internal/proxy/forward.go`. Read by column, the flagged expressions are the
image identifier a request carried (five sinks), the address a pack was asked
to route or a membership carries (four), the host a CONNECT named (two), and
the error a driver built out of one of those (four). Every one is a real flow:
none of those values is ours however internal it looks — `Runtime` is restored
verbatim by `PUT /_feint/state` and a snapshot is designed to travel, which is
CLAUDE.md's "well formed is not authorised".

**One shared function**, `internal/core/logline.Sanitise`, spells every
character that cannot stand in a printable line the way a Go literal spells it
(a newline as the two characters `\n`, an escape as `\x1b`, the line separator
U+2028 as its six-character form, a byte that is not UTF-8 as `\xff`) and
returns a printable value byte for byte. Spelled rather than dropped, because
the value being logged is usually the one the emulator just refused and an
operator has to read it; spelled rather than refused, because unlike
`cloudinit`'s `Spec.checkInjection` (a YAML render has no safe spelling) a log
has one.

**Where it lives, and why there.** `internal/core/machine` and `internal/proxy`
both need it and neither may import the other (`proxy` already imports
`core/emulator`, which imports `machine`). A leaf under `internal/core` is the
one place both reach without a cycle: it imports the standard library only and
names no provider, so the neutral-core rule holds. Placing it in `cloudinit`
was considered and refused — that package refuses, this one spells, and a
caller should not have to import a YAML renderer to log a hostname.

**How it is measured.** At the value the layer hands to the logger, read through
`slog.HandlerOptions.ReplaceAttr` before the handler quotes it. That is the whole
test design: `internal/cli`'s `TestALoggedClientValueCannotForgeALine` measured
in August that `slog.TextHandler` quotes a newline on its own, so a test reading
the handler's output stays green with every sanitiser removed. Tests, each cited
by the comment on the code it holds:

- `TestSanitiseSpellsEveryControlCharacter` and
  `TestSanitiseLeavesAPrintableValueAlone` — the function, both halves (the
  accepting half runs a dozen real machine names, hosts, image identifiers,
  addresses and a runtime error through it and requires identity);
- `TestNoClientValueForgesALineInTheBootLog` (binding.go: the refusal, the
  declaration, the failed build, the failed start) and
  `TestNoClientValueForgesALineInTheAddressLog` (plan.go: the refused route,
  the failed route, the failed unroute, the failed attach);
- `TestARefusedHostCannotForgeALogLine` (forward.go).

**Falsified.** `tools/falsify/specs/a-log-line-cannot-be-forged.json` declares
eleven mutations, one per sanitised expression a test can reach; `mise run
falsify` reports every one as "the test bit", compiled, green after
restoration (exit code 0, read off the command). `mise run falsify:lint` passes
over the 198 specs.

**Two things the harness refused to let this pull request claim, kept as they
are and written down.**

1. The two `strings.ReplaceAll` calls in `Sanitise` are redundant with its loop
   by design: they are the exact shape CodeQL's query recognises as a sanitiser
   (a `ReplaceAll` whose replaced string is `"\n"` or `"\r"`), and the loop
   spells a newline just as well. The first version of the spec mutated them
   and the harness answered "test still passed". No local test can hold those
   two lines; only the CodeQL job on this pull request does, and the spec no
   longer declares a mutation on them. The doc comment says so.
2. The `address` logged after a route or unroute failure (plan.go, two of the
   fifteen sinks) has passed `netip.ParseAddr` and `Prefix.Contains` two lines
   above, so no test can put a control character in it. Its two `Sanitise`
   calls keep the rule mechanical ("every client value in a log call goes
   through it") and let the analysis see the flow cut; the comment in `route`
   says they are not guards. If you would rather have no call that cannot
   fail, the alternative is to drop those two and dismiss alerts 52 and 58 as
   "validated by ParseAddr" — a decision I did not take on your behalf.

**Changelog: no entry, deliberately.** No response shape a client can observe
changes and no limit moves; a record the sink already quoted reads the same for
every printable value, which is every value the emulator logs in practice.

**Trailer.** The commit carries `Assisted-by:` and not `Co-Authored-By:`,
because CONTRIBUTING.md forbids the latter for a tool; the brief asked for the
latter, and this is the one place the brief and the repository disagree.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [x] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`) —
      through `mise run prepush`, exit code 0, read off the command itself
- [x] No new external Go dependency; `internal/core/logline` imports the standard
      library only, and `go.sum` still does not exist
- [x] `internal/core` still knows no provider (`TestTheCoreNamesNoProvider` is in
      `check`)
- [x] Nothing in the diff could be written identically for another provider: the
      function is in the core and the packs are untouched
- [x] `mise run testplan` was run. It printed thirteen falsify specs and the
      runtime leg. Played: this branch's own spec (eleven mutations, all bit),
      `falsify:lint` over every spec. **Not played, and why:**
      `FEINT_VM=incus-ovn mise run conformance:leg -- runtime` — the brief forbids
      starting a machine for this work, and the diff changes no command the
      driver emits, only the spelling of four log attributes; the twelve other
      specs the plan names because they mutate files this diff touches — their
      fragments all still apply (`falsify:lint`), and the replay was then played: ten of the twelve exit 0 with every mutation biting; two — `lifecycle-tells-the-truth` and `public-address-migration` — exit 1 because one mutation each is voided for not compiling, and the cause is a corrupted `replace` in those two spec files on `main` (`errors.Join(routed, err)ors.Join(routed, err)`), against an `incus_ovn.go` this branch leaves byte-identical to `origin/main`; the table and the evidence are in a comment below

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] `mise run conformance` — **not run, and said so**: the plan earned no
      client leg for this diff (no route, no response shape, no error shape
      moves), and the one leg it earned needs a machine runtime the brief
      forbids. A log attribute is not something a client can observe
- [x] N/A for field names: the diff carries no wire field; every string it
      touches is a log attribute

### When a route is added or changed — otherwise N/A

- [x] N/A — no route added or changed

### When behaviour a client can observe changes — otherwise N/A

- [x] N/A — `docs/limits.md` moves no limit; the README's generated tables read
      nothing this diff touches (`docs:check` is in `prepush`).
      `docs/architecture.md` gains one line naming the new package

### When `.github/workflows/` is touched — otherwise N/A

- [x] N/A — no workflow touched

### When a machine runtime is involved — otherwise N/A

- [x] N/A with a reason rather than a blank: `internal/core/machine` is touched,
      but on four log calls only; no command the driver emits changes, nothing
      is created or removed on the host, and the runtime leg was not run (see
      Always, and the brief)

## Related issues

No issue; the fifteen code-scanning alerts named above. Success is measured on
this pull request's CodeQL run, not here: the alerts must close on the branch.
