### PR TITLE
fix(machine): an OVN network names its own gateway as the lease's resolver, so no guest lays a dead route towards the uplink (#697)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -418,6 +418,34 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une machine qui porte une adresse publique et un réseau privé répond de
+  nouveau sur son adresse publiée sous `incus-ovn` : le réseau nomme sa propre
+  passerelle comme résolveur du bail** (#697). `runtime-proof` était rouge
+  quatre nuits planifiées (du 04 au 07 septembre) sur `platform-web-0` de
+  `examples/stacks/scaleway`, `waiting: platform-web-0 answers on port 443`,
+  pendant que la jambe témoin en v0.12.1 passait chacune d'elles. La requête
+  arrivait (une connexion en `SYN_RECV` dans l'invité) ; la réponse mourait
+  sur une `/32` on-link vers `10.209.83.1`, l'adresse de l'uplink, celle
+  depuis laquelle la station appelle et qui n'est pas sur le segment de
+  l'invité. Cette route est celle de l'invité lui-même, `RoutesToDNS=` vers
+  le serveur DNS que son bail nomme, et depuis #693 le bail n'en nommait
+  aucun, si bien qu'Incus nommait l'adresse de l'uplink à sa place : ne rien
+  nommer n'était pas « pas de route ». Trois valeurs mesurées, deux
+  rejetées : `RoutesToDNS=no` dans le drop-in de l'invité ne change rien, le
+  bail pose la route avant que le drop-in n'arrive ; un résolveur public
+  répare la réponse et déplace la `/32` morte vers `1.1.1.1`, ce qui est #684
+  qui revient. La passerelle est sur le segment par construction : routes
+  nommant l'uplink `0`, aucune `/32` morte ailleurs, la réponse
+  `via <passerelle>`, et la station joint l'adresse publiée. Rien ne répond
+  au DNS sur la passerelle, et rien n'a à le faire : le serveur de noms
+  qu'une machine utilise vient du drop-in et de `resolvectl` (#694, #696), et
+  la valeur du bail ne décide que de la route posée.
+  `TestAnOVNNetworkLaysNoRouteTowardsItsResolver` tient l'invariant plutôt
+  qu'une valeur : tout serveur de noms que le bail nomme est sur le segment,
+  et il en nomme un. La moitié sortante de #695 n'est pas ceci : une machine
+  qui porte une adresse publique n'a toujours pas de route par défaut sous
+  OVN.
+
 - **`osc/Client.ReadVms` refuse une valeur de `VmIds` qui n'est pas un
   identifiant** (#396), comme le vrai compte, et comme aucune autre lecture.
   L'enregistrement du 2026-08-21 (`corpus/outscale/oapi-cli-refusals.jsonl`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,31 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A machine holding a public address and a private network answers at its
+  published address again under `incus-ovn`: the network names its own
+  gateway as the lease's resolver** (#697). `runtime-proof` was red four
+  scheduled nights (09-04 to 09-07) on `platform-web-0` of
+  `examples/stacks/scaleway`, `waiting: platform-web-0 answers on port 443`,
+  while the control leg at v0.12.1 passed each of them. The request landed
+  (one connection in `SYN_RECV` inside the guest); the reply died on an
+  on-link `/32` towards `10.209.83.1`, the uplink's address, which is what
+  the station dials from and is not on the guest's segment. That route is
+  the guest's own, `RoutesToDNS=` towards the DNS server its lease names,
+  and since #693 the lease named none, so Incus named the uplink's address
+  for it: naming nothing was not "no route". Three values measured, two
+  rejected: `RoutesToDNS=no` in the guest's drop-in changes nothing, the
+  lease lays the route before the drop-in lands; a public resolver repairs
+  the reply and moves the dead `/32` to `1.1.1.1`, which is #684 back. The
+  gateway is on the segment by construction: routes naming the uplink `0`,
+  no dead `/32` elsewhere, the reply `via <gateway>`, and the station reaches
+  the published address. Nothing answers DNS at the gateway, and nothing has
+  to: the name server a machine uses comes from the drop-in and `resolvectl`
+  (#694, #696), and the lease's value decides only which route is laid.
+  `TestAnOVNNetworkLaysNoRouteTowardsItsResolver` holds the invariant rather
+  than a value — every name server the lease names is on the segment, and it
+  names one. The outbound half of #695 is not this: a machine holding a
+  public address still has no default route under OVN.
+
 - **`osc/Client.ReadVms` refuses a `VmIds` value that is not an identifier**
   (#396), as the real account does and as no other read does. The recording
   of 2026-08-21 (`corpus/outscale/oapi-cli-refusals.jsonl`) sent

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -2186,26 +2186,35 @@ network underneath — and therefore no NAT and no resolver, because the images
 `feint images` builds carry their ssh daemon already (#203) and nothing else
 about the machine needs the internet.
 
-**An OVN network announces a public resolver, never the uplink's address
-(#660).** The machines that boot on it are told `feint serve --resolver`
-(default `1.1.1.1`): the uplink's own address is also the one the station
-dials a public address from, and a guest's `RoutesToDNS=` laid an on-link
-`/32` towards it that killed every reply — measured 2026-09-04, `ip route get
-10.209.83.1` from the guest answered `dev eth1` with the uplink announced and
-`via <gateway> dev eth1` with a public one, and the platform's published
-address answered again. **What that does not establish is name resolution.**
-Measured the same day on the same stack: the announcement was on the wire
-(OVN's `DHCP_Options` row carried `dns_server={1.1.1.1}`), and the guest's
-`resolved` held no server on any link, on a machine with a way out as on one
-without; set by hand, the same machine resolved, so the path is open and the
-guest is not applying the lease's DNS (`networkctl renew eth1`: "not managed
-by systemd-networkd", on an interface carrying a dynamic address). That is a
-defect of its own, followed apart from #660; until it is read, do not write
-here that a machine with a way out resolves, nor that one without does not
-because of the resolver it was told. The default route inside the guest is
-`via 169.254.0.1`, the routed NIC's link-local next hop, and it wins even when
-a private NIC with a NAT-backed network is attached later, which is the
-ordinary Terraform order on Scaleway and Exoscale (server first, NIC after).
+**An OVN network names its own gateway as the lease's resolver — never the
+uplink's address, never a public one, never nothing (#660, #684, #697).**
+The machines that boot on it get the name server they use another way:
+`feint serve --resolver` (default `1.1.1.1`), written where systemd-networkd
+reads it and set with `resolvectl` (#694, #696). What the lease names decides
+one thing, the on-link `/32` a guest's `RoutesToDNS=` lays towards it, and
+that route is dead the moment the address is off the segment. Three values
+were measured, all under `incus-ovn`, and the invariant they share is what
+`TestAnOVNNetworkLaysNoRouteTowardsItsResolver` holds: the uplink's own
+address, which is also the one the station dials a public address from —
+2026-09-04, `ip route get 10.209.83.1` from the guest answered `dev eth1` and
+the platform's published address answered nothing; a public resolver,
+2026-09-04 — `1.1.1.1 dev eth0 proto dhcp scope link`, `ping 1.1.1.1`
+unreachable, and the machine could not resolve; and none at all, 2026-09-07 —
+Incus names the uplink's address when nobody else does, and the first shape
+came back for four scheduled nights on `platform-web-0`, a public address and
+a private network, while the same stack at v0.12.1 passed each of them
+(#697). With the gateway named, the guest holds no route towards the uplink,
+no dead `/32` anywhere, the reply leaves `via <gateway>`, and the station
+reaches the published address. Name resolution rides the drop-in, not the
+lease: a machine with a way out resolves through it (measured on the shapes
+of #694 and #696, `dns: ok` after a cold attach and after a reboot), and one
+holding a public address has no way out under OVN to resolve through, which
+is #695's outbound half. The default route inside the guest is
+`via 169.254.0.1`, the routed NIC's link-local next hop, in **bridge mode**,
+where it wins even when a private NIC with a NAT-backed network is attached
+later, the ordinary Terraform order on Scaleway and Exoscale (server first,
+NIC after); under OVN the routed device carries no address and the guest has
+no default route at all ("Which door a reply leaves by", below).
 Outscale's Subnets are NAT-less **on purpose and faithfully**: upstream, a
 Subnet reaches out only through an internet or NAT service, and this emulator
 records those without routing them (see "Outscale's gateways and NAT move
@@ -2301,10 +2310,13 @@ inbound. It is the reply that never reaches the wire.
 
 The on-link route itself is DHCP's: `10.209.83.1 dev eth1 proto dhcp scope
 link`. `systemd-networkd` lays an on-link `/32` toward every DNS server a lease
-announces (`RoutesToDNS=`), and the OVN network announces the uplink as its
-resolver. A `/32` beats any default route by longest prefix, which is why #672's
-two variants of this shape read *"same gateway, same device, opposite results"*:
-the gateway and device were never the deciding part.
+announces (`RoutesToDNS=`), and the OVN network named none — #693 had taken
+the public resolver out of the lease for the same reason (#684) — so Incus
+named the uplink for it. A `/32` beats any default route by longest prefix,
+which is why #672's two variants of this shape read *"same gateway, same
+device, opposite results"*: the gateway and device were never the deciding
+part. Since #697 the lease names the network's own gateway, the one address
+on the segment, and the `/32` is live.
 
 ### What the routed NIC does, per mode
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -961,7 +961,7 @@ func serve(args []string, stdout io.Writer) error {
 	addr := fs.String("addr", DefaultAddr, "listen address")
 	state := fs.String("state", "", "load and persist the store to this JSON file")
 	vm := fs.String("vm", "off", "back powered-on servers with real machines: off, incus, incus-vm, incus-ovn, auto")
-	resolver := fs.String("resolver", machine.DefaultResolver, "the name server an OVN network announces to its machines; never the uplink's own address (#660)")
+	resolver := fs.String("resolver", machine.DefaultResolver, "the name server the machines of an OVN network are given; never the uplink's own address (#660)")
 	cleanup := fs.Bool("cleanup", false, "remove the machines and networks this run created before exiting")
 	logLevel := fs.String("log-level", "info", "log verbosity: error, warn, info, debug")
 	contracts := fs.String("contracts", "", "directory of API contracts; every response is checked against them and /_feint/conformance reports what failed")

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -73,7 +73,7 @@ func bindServeFlags(fs *flag.FlagSet) *serveFlags {
 	fs.StringVar(&f.state, "state", "", "load and persist the store to this JSON file")
 	fs.StringVar(&f.vm, "vm", "off", "back powered-on servers with real machines: off, incus, incus-vm, incus-ovn, auto")
 	fs.BoolVar(&f.cleanup, "cleanup", false, "remove the machines and networks this run created before exiting")
-	fs.StringVar(&f.resolver, "resolver", "", "the name server an OVN network announces to its machines; never the uplink's own address (#660)")
+	fs.StringVar(&f.resolver, "resolver", "", "the name server the machines of an OVN network are given; never the uplink's own address (#660)")
 	fs.StringVar(&f.logLevel, "log-level", "info", "log verbosity: error, warn, info, debug")
 	fs.StringVar(&f.contracts, "contracts", "", "directory of API contracts; every response is checked against them")
 	// Bound here as well as on `serve`, because `up` renders it into the `start`

--- a/internal/core/machine/incus.go
+++ b/internal/core/machine/incus.go
@@ -55,12 +55,14 @@ type Incus struct {
 	// UplinkCIDR is the block the uplink carries. Empty means
 	// DefaultUplinkCIDR.
 	UplinkCIDR string
-	// Resolver is the name server an OVN network announces to the machines
-	// that boot on it (#660). Empty means DefaultResolver. A field rather
-	// than a constant: an emulator on a station without Internet says which
-	// resolver it has, and a station whose resolver differs sets it. What it
-	// may never be is the uplink's own address, and EnsureNetwork refuses
-	// that value (see the note there).
+	// Resolver is the name server the machines of an OVN network are given
+	// (#660). Empty means DefaultResolver. A field rather than a constant: an
+	// emulator on a station without Internet says which resolver it has, and
+	// a station whose resolver differs sets it. It reaches a guest through a
+	// networkd drop-in and resolvectl, never through the lease (#684, #694,
+	// #696): the lease names the network's own gateway, and EnsureNetwork
+	// says why. What this field may never be is the uplink's own address,
+	// and EnsureNetwork refuses that value (see the note there).
 	Resolver string
 	// Log is where this driver says what it could not do. Nil means the
 	// default logger, which is what the CLI configures.
@@ -1413,82 +1415,95 @@ func (d *Incus) EnsureNetwork(ctx context.Context, spec NetworkSpec) error {
 		// TestAnOVNNetworkAnnouncesNoGateway and
 		// TestAnOVNNetworkAnnouncesItsPrivateRoutes fail without this.
 		//
-		// And the network never announces, as its resolver, the address by
-		// which the station reaches its machines (#660). Left alone, Incus
-		// announces the uplink's own address (10.209.83.1) as the DNS server,
-		// and that address is also the source the station dials from, since
-		// the host route to a public address routed onto an OVN NIC goes
-		// `dev feint-uplink src 10.209.83.1`. Inside the guest, systemd-networkd's
+		// And what the network names as its resolver is the one address a
+		// lease may safely name: its own gateway. Three measurements decide
+		// it, and the invariant they share is what the test holds — no guest
+		// lays an on-link route towards a host outside its own segment.
+		//
+		// The mechanism first. Inside the guest, systemd-networkd's
 		// RoutesToDNS= — on by default — lays an on-link /32 towards every
 		// DNS server the lease names, more specific than the aggregates the
-		// network announces towards its router; the reply to the station then
-		// ARPs for 10.209.83.1 on the logical switch, nobody answers, and the
-		// machine is unreachable at its published address. Measured on
-		// 2026-09-04 under `--vm incus-ovn`: `ip route get 10.209.83.1` from
-		// the guest answered `dev eth1` (on-link, dead); with the resolver a
-		// public address it answers `via <gateway> dev eth1`, through the
-		// router; and `ip route del 10.209.83.1 dev eth1` turned a dial of
-		// 203.0.113.3:443 from 000 into 200, `ip route add` turned it back.
+		// network announces towards its router. A /32 towards an address that
+		// is NOT on the segment is dead: the guest ARPs for it on the logical
+		// switch and nobody answers.
 		//
-		// RoutesToDNS= is the guest's own, ordinary mechanism, and this is not
-		// a workaround of a systemd defect: the collision is what made an
-		// ordinary behaviour harmful, and the announcement below removes the
-		// collision. The network's gateway was measured and rejected as the
-		// alternative — nothing answers DNS there, so a machine with a way out
-		// would stop resolving, which is worse than the defect.
+		// #660 measured it with the uplink's own address (10.209.83.1), which
+		// Incus names when nobody else does. That address is also the source
+		// the station dials from, since the host route to a public address
+		// routed onto an OVN NIC goes `dev feint-uplink src 10.209.83.1`, so
+		// the reply to the station died on the switch: 2026-09-04, `ip route
+		// del 10.209.83.1 dev eth1` turned a dial of 203.0.113.3:443 from 000
+		// into 200, `ip route add` turned it back. #660 answered by naming a
+		// public resolver.
 		//
-		// What this does NOT establish, measured the same day: that a machine
-		// with a way out resolves through the announced resolver. On the
-		// station measured, the announcement was on the wire (the OVN
-		// DHCP_Options row carried dns_server={1.1.1.1}) and the guest's
-		// resolved held no server on any link; set by hand (`resolvectl dns
-		// eth1 1.1.1.1`) the same machine resolved, so the path is open and
-		// the guest is not applying the lease's DNS — `networkctl renew eth1`
-		// answered that the interface is not managed by systemd-networkd
-		// while it carried a dynamic address. That is a defect of its own,
-		// followed apart from #660. The resolver is a field (Resolver,
-		// `feint serve --resolver`) so a station without Internet, or with a
-		// resolver of its own, can say so; the uplink's address is refused
-		// whatever the field says.
+		// #684 measured that the same mechanism breaks a public resolver, for
+		// the same reason, the moment the interface is managed at all:
 		//
-		// TestAnOVNNetworkLaysNoRouteTowardsItsResolver and
-		// TestAResolverThatIsTheUplinkIsRefused fail without this.
+		//	1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
+		//	ip route get 1.1.1.1 -> 1.1.1.1 dev eth0 src 10.188.0.5
+		//	ping 1.1.1.1 -> unreachable, resolvectl -> No route to host
+		//
+		// so #693 named nothing in the lease, and gave the guest its resolver
+		// through resolvectl and a networkd drop-in instead (#694, #696),
+		// which set a name server and lay no route.
+		//
+		// #697 measured that naming nothing is not "no route". Incus falls
+		// back to the host's resolvers when a network names none, and under
+		// OVN that is the uplink: the guest laid #660's dead /32 towards
+		// 10.209.83.1 all the same, and platform-web-0 — a public address AND
+		// a private network, examples/stacks/scaleway — answered nothing at
+		// its published address four scheduled nights running (09-04 to
+		// 09-07) while the same stack at v0.12.1 passed each of them.
+		// Measured 2026-09-07 under `--vm incus-ovn`, the service proved
+		// listening inside before any verdict: the request lands (one
+		// connection in SYN_RECV while the station dials), the reply's route
+		// to the peer is `dev eth0` on-link with no `via`, the neighbour
+		// INCOMPLETE; the /32 deleted by hand, `via 10.213.0.1 dev eth0` and
+		// the station reaches it; the /32 put back, unreachable again.
+		//
+		// Two fixes measured and rejected the same day. `RoutesToDNS=no` in
+		// the guest's drop-in: no effect, twice — the lease lays the route
+		// before the drop-in lands, and the reload does not withdraw it. A
+		// public resolver in the lease: repairs the reply and MOVES the dead
+		// /32 to 1.1.1.1, which is #684 back. The gateway is what held:
+		// routes naming the uplink 0, no dead /32 anywhere else, the reply
+		// `via <gateway> dev eth0`, and the station reaches the published
+		// address.
+		//
+		// The gateway was rejected in #660 because nothing answers DNS there,
+		// and nothing does. That stopped being an objection with #694 and
+		// #696: the name server the guest USES comes from the drop-in and
+		// resolvectl, ahead of the lease's in resolved's list, so the value
+		// in the lease decides one thing only — which /32 the guest lays —
+		// and the gateway is the one address that is on the segment by
+		// construction. The resolver is a field (Resolver, `feint serve
+		// --resolver`) so a station without Internet, or with a resolver of
+		// its own, can say so; the uplink's address is refused whatever the
+		// field says, since a guest that lays a route towards it answers the
+		// station through a dead /32.
+		//
+		// What this does not do: lay a default route for a machine holding a
+		// public address. That is the outbound half of #695, and it is
+		// unblocked by this rather than blocked: with the reply travelling
+		// via the router, a default route through the same gateway changes
+		// nothing about it.
+		//
+		// TestAnOVNNetworkLaysNoRouteTowardsItsResolver holds the invariant on
+		// both modes, and TestAResolverThatIsTheUplinkIsRefused the refusal;
+		// both fail without this.
 		gateway, err := d.uplinkGateway()
 		if err != nil {
 			return err
 		}
 		resolver := d.resolver()
 		if resolver == gateway.String() {
-			return fmt.Errorf("refusing to create network %s: the resolver %s is the uplink's own address, which is also the address the station reaches this network's machines from; announcing it lays a dead on-link route inside every guest (#660)",
+			return fmt.Errorf("refusing to create network %s: the resolver %s is the uplink's own address, which is also the address the station reaches this network's machines from; a guest that lays a route towards it answers the station through a dead on-link /32 (#660)",
 				spec.Name, resolver)
 		}
-		// The resolver is NOT announced over DHCP, and that is measured
-		// rather than a simplification (#684). A guest whose stack manages the
-		// interface answers a DHCP-announced name server by laying an on-link
-		// /32 towards it — systemd's RoutesToDNS=, on by default — and a public
-		// resolver is not on the subnet, so the guest ARPs for it on its own
-		// segment and reaches nothing. Read from a machine entitled to egress,
-		// 2026-09-04 under `--vm incus-ovn`:
-		//
-		//	1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
-		//	ip route get 1.1.1.1 -> 1.1.1.1 dev eth0 src 10.188.0.5
-		//	ping 1.1.1.1 -> unreachable, resolvectl -> No route to host
-		//
-		// Delete that one route and the same machine reaches 1.1.1.1; put the
-		// resolver back on the link by hand and `getent hosts deb.debian.org`
-		// answers. So the announcement is what breaks the way out, and the
-		// resolver reaches the guest through resolvectl instead
-		// (settleGuestInterface), which configures a name server without laying
-		// a route to it.
-		//
-		// This was invisible until #684: with the interface managed by nobody,
-		// no lease was applied and no route was laid, so the machine had no
-		// resolver AND its way out. Fixing one exposed the other.
-		//
-		// TestAnOVNNetworkLaysNoRouteTowardsItsResolver fails without this.
 		args = append(args,
 			"ipv4.dhcp.gateway=none",
 			"ipv4.dhcp.routes="+announcedPrivateRoutes(address),
+			"dns.nameservers="+gatewayHost(address),
 		)
 	}
 	for k, v := range spec.Labels {

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -47,14 +47,16 @@ const (
 	// collision with a block already routed on the operator's host makes the
 	// create fail, and failing is better than capturing someone's traffic.
 	DefaultUplinkCIDR = "10.209.83.0/24"
-	// DefaultResolver is the name server an OVN network announces when the
-	// operator names none (#660): a public one, as a public cloud announces
-	// (a Scaleway instance receives 51.159.47.28), and the address this
-	// repository already uses as its witness of public reachability
-	// (tools/images/verify.sh). Any public address does the job the decision
-	// asks — the /32 RoutesToDNS= lays towards it goes through the network's
-	// router, measured — and this one answers queries from anywhere, so a
-	// machine WITH a way out still resolves.
+	// DefaultResolver is the name server the machines of an OVN network are
+	// given when the operator names none (#660): a public one, as a public
+	// cloud gives (a Scaleway instance receives 51.159.47.28), and the
+	// address this repository already uses as its witness of public
+	// reachability (tools/images/verify.sh), so a machine WITH a way out
+	// resolves. It reaches the guest through a networkd drop-in and
+	// resolvectl (#694, #696), never through the lease: a name server in the
+	// lease gets an on-link /32 from RoutesToDNS=, and a public address is
+	// not on the segment (#684). What the lease names is the network's own
+	// gateway, and EnsureNetwork says why (#697).
 	DefaultResolver = "1.1.1.1"
 )
 
@@ -1093,15 +1095,24 @@ var privateAggregates = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"
 // machines of one VPC that had always reached each other, because the default
 // route the network used to announce had been carrying the peered subnets too.
 func announcedPrivateRoutes(address string) string {
-	gateway := address
-	if host, _, ok := strings.Cut(address, "/"); ok {
-		gateway = host
-	}
+	gateway := gatewayHost(address)
 	pairs := make([]string, 0, len(privateAggregates))
 	for _, block := range privateAggregates {
 		pairs = append(pairs, block+","+gateway)
 	}
 	return strings.Join(pairs, ",")
+}
+
+// gatewayHost is the host part of the gateway CIDR a network carries
+// (10.0.0.1/24 -> 10.0.0.1): what a DHCP option takes, where the network
+// itself takes the CIDR. Shared by the routes and the name server the lease
+// names, so the two cannot disagree about which address the segment's router
+// answers on.
+func gatewayHost(address string) string {
+	if host, _, ok := strings.Cut(address, "/"); ok {
+		return host
+	}
+	return address
 }
 
 // guestRoutePoll and guestRouteWait bound the wait for a restarted guest to

--- a/internal/core/machine/plan.go
+++ b/internal/core/machine/plan.go
@@ -80,11 +80,16 @@ type Plan struct {
 	//
 	// The third is the one that was missing. A machine holding a routed public
 	// address already has a default route, laid by RouteAddress towards the
-	// uplink, and it is the route its INBOUND traffic must answer through.
-	// Naming a network for it made the reconciler replace that route with the
-	// private network's gateway, and a machine whose reply left by another door
-	// answered nothing at all: measured on the example stacks, platform-web-0
-	// served 443 inside and was unreachable at its published address.
+	// uplink, and naming a network for it made the reconciler replace that
+	// route with the private network's gateway: measured on the example
+	// stacks, platform-web-0 served 443 inside and was unreachable at its
+	// published address. The door was read as the cause at the time; #672
+	// measured that it is not what decides — the same gateway and device gave
+	// opposite results — and #697 found what does: the on-link /32 the guest
+	// lays towards the name server its lease names (RoutesToDNS=), which beats
+	// any default route by prefix length. A plan claiming the default route
+	// twice is still a contradiction, and Reconciler.Expect refuses it before
+	// the runtime is asked (#667); the diagnosis moved, not the rule.
 	//
 	// Empty-and-not-refused is also the safe default for a pack that says
 	// nothing, which the previous shape was not: silence meant "take it away".

--- a/internal/core/machine/resolver_internal_test.go
+++ b/internal/core/machine/resolver_internal_test.go
@@ -3,36 +3,39 @@ package machine
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-// An OVN network hands its machines a resolver without ever announcing one in
-// the lease (#660, and the half of it that #684 closed).
+// An OVN network names, in its lease, the one address a guest may safely lay
+// an on-link route towards: its own gateway (#660, #684, #697).
 //
-// #660 measured the first half: the uplink's address, announced as the DNS
-// server, is also the source the station dials from, so the guest's
-// RoutesToDNS= laid an on-link /32 towards it, more specific than the
-// aggregates, and the reply to the station died on the switch. Its answer was
-// to announce a public resolver instead. The network's gateway was rejected as
-// the alternative, and re-measured on 2026-09-04 with the check made
-// independent of the others: nothing answers DNS there, `getent` returns
-// nothing on all three shapes.
+// The invariant is the guest's. systemd-networkd's RoutesToDNS= lays an
+// on-link /32 towards every DNS server a lease names, and a /32 towards an
+// address that is not on the segment is dead — the guest ARPs for it on the
+// switch and nobody answers. Three values were measured against it:
 //
-// #684 measured the second half, once the interfaces were managed at all. THE
-// SAME MECHANISM BREAKS A PUBLIC RESOLVER, for the same reason: a name server
-// in the lease gets an on-link /32, and 1.1.1.1 is not on the subnet either.
+//   - the uplink's address, which Incus names when nobody else does (#660,
+//     and #697 again through that fallback): it is also the source the
+//     station dials from, so the reply to a published address died on the
+//     switch;
+//   - a public resolver (#684): 1.1.1.1 is not on the segment either,
 //
 //	1.1.1.1 dev eth0 proto dhcp scope link src 10.188.0.5 metric 100
 //	ping 1.1.1.1 -> unreachable; resolvectl query -> No route to host
-//	ip route del 1.1.1.1 dev eth0 -> reachable
-//	resolvectl dns eth0 1.1.1.1 -> getent hosts deb.debian.org answers
 //
-// So no resolver is announced in the lease at all. The one the network stands
-// for reaches the guest through resolvectl (setGuestResolver), which sets a
-// name server and lays no route.
+//   - nothing (#693): not "no route" — Incus falls back to the host's
+//     resolvers, under OVN the uplink, and #660's dead /32 came back through
+//     somebody else's default. Four red scheduled nights on platform-web-0
+//     (#697).
+//
+// The gateway is on the segment by construction, so the /32 towards it is
+// live and harmless. Nothing answers DNS there, and that stopped mattering
+// with #694 and #696: the name server the guest uses reaches it through a
+// networkd drop-in and resolvectl, ahead of the lease's, and lays no route.
 
 // resolverProbe is the uplink harness of the egress tests: an uplink this run
 // holds on 10.99.0.0/24 (gateway 10.99.0.1), and the network absent so
@@ -46,21 +49,49 @@ func resolverProbe() *fakeRuntime {
 	}}
 }
 
-func networkCreateLine(f *fakeRuntime) string {
+// networkCreateCall is the create as argv, for the assertions that read one
+// option's value rather than grep the line.
+func networkCreateCall(f *fakeRuntime) []string {
 	for _, call := range f.calls {
-		line := strings.Join(call, " ")
-		if strings.Contains(line, "network create fnt-probe") {
-			return line
+		if strings.Contains(strings.Join(call, " "), "network create fnt-probe") {
+			return call
 		}
 	}
-	return ""
+	return nil
 }
 
-// TestAnOVNNetworkLaysNoRouteTowardsItsResolver holds the whole property: no
-// name server is put in the lease, by either mode, so no guest lays an on-link
-// route towards one. A bridge never did — its dnsmasq is the resolver there,
+func networkCreateLine(f *fakeRuntime) string {
+	return strings.Join(networkCreateCall(f), " ")
+}
+
+// announcedNameServers reads the name servers a create puts in the lease:
+// none when the option is absent or empty, and the two are deliberately not
+// told apart — both make Incus fall back to the host's resolvers, the empty
+// key measured on #694.
+func announcedNameServers(call []string) []string {
+	var servers []string
+	for _, arg := range call {
+		value, ok := strings.CutPrefix(arg, "dns.nameservers=")
+		if !ok {
+			continue
+		}
+		for _, server := range strings.Split(value, ",") {
+			if server = strings.TrimSpace(server); server != "" {
+				servers = append(servers, server)
+			}
+		}
+	}
+	return servers
+}
+
+// TestAnOVNNetworkLaysNoRouteTowardsItsResolver holds the invariant rather
+// than one value of it: every name server the lease names is on the network's
+// own segment, and the lease names one — an absent option is the uplink by
+// Incus's fallback, which is the four red nights of #697 and not a safer
+// state. A bridge names none itself: its dnsmasq is the resolver there,
 // on-link by construction, and the collision does not exist.
 func TestAnOVNNetworkLaysNoRouteTowardsItsResolver(t *testing.T) {
+	const block = "10.99.1.0/24"
 	for _, mode := range []struct {
 		name string
 		ovn  bool
@@ -71,22 +102,40 @@ func TestAnOVNNetworkLaysNoRouteTowardsItsResolver(t *testing.T) {
 			d.OVN = mode.ovn
 			d.UplinkCIDR = "10.99.0.0/24"
 			if err := d.EnsureNetwork(context.Background(), NetworkSpec{
-				Name: "fnt-probe", CIDR: "10.99.1.0/24", NAT: true,
+				Name: "fnt-probe", CIDR: block, NAT: true,
 			}); err != nil {
 				t.Fatalf("ensure: %v", err)
 			}
-			line := networkCreateLine(f)
-			if line == "" {
+			call := networkCreateCall(f)
+			if call == nil {
 				t.Fatalf("no network create; calls: %v", f.calls)
 			}
-			if strings.Contains(line, "dns.nameservers") {
-				t.Errorf("a name server is in the lease, which is the on-link /32 that costs the machine its way out (#684): %s", line)
+			servers := announcedNameServers(call)
+			if !mode.ovn {
+				if len(servers) > 0 {
+					t.Errorf("a bridge network names %v in its lease, over the dnsmasq that answers on-link there: %v", servers, call)
+				}
+				return
+			}
+			if len(servers) == 0 {
+				t.Fatalf("the OVN network names no resolver in its lease, so Incus names the uplink's address for it and every guest lays a dead on-link /32 towards the station's own source (#697): %v", call)
+			}
+			segment := netip.MustParsePrefix(block)
+			for _, server := range servers {
+				addr, err := netip.ParseAddr(server)
+				if err != nil {
+					t.Errorf("the lease names %q, which is not an address: %v", server, err)
+					continue
+				}
+				if !segment.Contains(addr) {
+					t.Errorf("the lease names %s, outside %s: the on-link /32 RoutesToDNS= lays towards it is dead, whether the address is the uplink's (#660) or a public resolver's (#684)", server, segment)
+				}
 			}
 			// And the accepting half, or a create that stopped configuring
 			// anything at all would pass: the routes ARE announced, and they
 			// are what a guest needs from the lease.
-			if mode.ovn && !strings.Contains(line, "ipv4.dhcp.routes=") {
-				t.Errorf("the OVN network announces no routes either, so this test is measuring an empty create: %s", line)
+			if !strings.Contains(strings.Join(call, " "), "ipv4.dhcp.routes=") {
+				t.Errorf("the OVN network announces no routes either, so this test is measuring an empty create: %v", call)
 			}
 		})
 	}

--- a/internal/core/machine/resolver_internal_test.go
+++ b/internal/core/machine/resolver_internal_test.go
@@ -141,9 +141,15 @@ func TestAnOVNNetworkLaysNoRouteTowardsItsResolver(t *testing.T) {
 	}
 }
 
-// TestAResolverThatIsTheUplinkIsRefused: the field cannot put the collision
-// back. The value the uplink was given is the value refused, derived once
-// (uplinkGateway), and no network is created.
+// TestAResolverThatIsTheUplinkIsRefused: the field cannot name the uplink.
+// Since #697 the field no longer reaches the lease — the lease names the
+// gateway, the field goes through the drop-in and resolvectl, which lay no
+// route — so what this protects has moved: it is the guard against the
+// announcement coming back through the field, the way #660's first fix put
+// `dns.nameservers=<resolver>` in the lease, and against a guest being
+// pointed, by any door, at the one address that is the station's own source
+// towards it. The value the uplink was given is the value refused, derived
+// once (uplinkGateway), and no network is created.
 func TestAResolverThatIsTheUplinkIsRefused(t *testing.T) {
 	f := resolverProbe()
 	d := newFakeDriver(f)

--- a/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
+++ b/tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json
@@ -2,11 +2,19 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
-      "label": "the network puts a name server back in the lease, which is the on-link /32 that costs a machine its way out (#684)",
+      "label": "the lease names the public resolver instead of the gateway, which moves the dead /32 to 1.1.1.1 rather than removing it (#684, #697)",
       "file": "internal/core/machine/incus.go",
       "package": "./internal/core/machine/",
-      "find": "\t\targs = append(args,\n\t\t\t\"ipv4.dhcp.gateway=none\",\n\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address),\n\t\t)",
-      "replace": "\t\targs = append(args,\n\t\t\t\"ipv4.dhcp.gateway=none\",\n\t\t\t\"ipv4.dhcp.routes=\"+announcedPrivateRoutes(address),\n\t\t\t\"dns.nameservers=\"+resolver,\n\t\t)",
+      "find": "\t\t\t\"dns.nameservers=\"+gatewayHost(address),",
+      "replace": "\t\t\t\"dns.nameservers=\"+resolver+gatewayHost(address)[:0],",
+      "test": "TestAnOVNNetworkLaysNoRouteTowardsItsResolver"
+    },
+    {
+      "label": "the lease names no resolver, so Incus names the uplink's address for it and #660's dead /32 comes back through the fallback (#697)",
+      "file": "internal/core/machine/incus.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\t\"dns.nameservers=\"+gatewayHost(address),",
+      "replace": "\t\t\t\"dns.nameservers=\"+gatewayHost(address)[:0],",
       "test": "TestAnOVNNetworkLaysNoRouteTowardsItsResolver"
     },
     {


### PR DESCRIPTION
# Summary

`runtime-proof` was red four scheduled nights (09-04 to 09-07) on
`platform-web-0` of `examples/stacks/scaleway` — a public address **and** a
private network — with `waiting: platform-web-0 answers on port 443`, while the
control leg at v0.12.1 passed each of them. #697 carries the measurement: the
request lands (one connection in `SYN_RECV` inside the guest), and the reply
dies on an on-link `/32` towards `10.209.83.1`, the uplink's address, which is
what the station dials from and is not on the guest's segment.

That route is the guest's own (`RoutesToDNS=` towards the DNS server its lease
names). Since #693 the lease named none, and Incus names the uplink's address
when nobody else does. Naming nothing was not "no route".

**The network now names its own gateway as the lease's resolver.** Of the three
values measured in #697, it is the only one on the segment: `RoutesToDNS=no`
in the guest's drop-in changes nothing (the lease lays the route before the
drop-in lands), and a public resolver moves the dead `/32` to `1.1.1.1`, which
is #684 back. Nothing answers DNS at the gateway and nothing has to: the name
server a machine uses comes from the drop-in and `resolvectl` (#694, #696), so
the lease's value decides only which route is laid.

What this changes, file by file:

- `internal/core/machine/incus.go`: `dns.nameservers=<gateway>` on an OVN
  network create, beside `ipv4.dhcp.gateway=none` and `ipv4.dhcp.routes=`.
  The comment that rejected the gateway because "nothing answers DNS there"
  is rewritten; that objection is obsolete since #694. The uplink refusal
  stays, and its message no longer says the field is announced.
- `internal/core/machine/resolver_internal_test.go`:
  `TestAnOVNNetworkLaysNoRouteTowardsItsResolver` forbade **any**
  `dns.nameservers`, which is precisely the fix. It now holds the invariant:
  every name server the lease names is on the network's own segment, **and
  it names one** (an absent option is the uplink by Incus's fallback). The
  bridge half and the `ipv4.dhcp.routes=` half are kept, so an empty create
  still fails it.
- `tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json`: the
  first mutation was the fix itself; replaced by two that bite the new
  invariant (a public resolver named; no resolver named).
- `internal/core/machine/plan.go`: `Plan.NoEgress`'s comment carried the
  diagnosis #672 replaced ("a reply that left by another door"); it now names
  what decides.
- `docs/limits.md`, the `Resolver` field, `DefaultResolver`, both `--resolver`
  help texts: say what the lease names and where the resolver goes instead.
- `CHANGELOG.md` / `CHANGELOG.fr.md`: the entry.

Not fixed, named: the outbound half of #695. A machine holding a public address
still has no default route under OVN, and with the reply travelling via the
router, that half is unblocked by this rather than blocked.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it. The
      standard library covers routing, JSON and Go parsing; `go.mod` has three
      lines and a pre-commit hook keeps it that way
- [x] `internal/core` still knows no provider. If a change seemed to require it,
      the pack changed instead
- [x] Nothing in the diff could be written identically for another provider. If
      it could, it belongs in the core — that is the rule that stopped the same
      lifecycle bug being fixed once and surviving twice
- [x] `mise run testplan` was run, and what it printed was run — or this pull
      request names the run it skipped and why. Run: `mise run check`,
      `mise run falsify -- tools/falsify/specs/an-ovn-network-announces-a-public-resolver.json`
      (26 mutations, all compile, all bite), `mise run falsify:lint`,
      `FEINT_VM=incus-ovn mise run conformance:leg -- runtime` (1458 s: the
      four suites pass, the verification guard reds on one Exoscale claim
      that breaks identically on `main` without this change, #741),
      `FEINT_VM=incus-ovn FEINT_FUNCTIONAL_PASSES=1 mise run conformance:functional`
      (the stack gate is the population the defect lives in, and the runtime
      leg does not carry it: `up` passes, `platform-web-0 answers at
      203.0.113.3:443`, then the reboot comparison reds on #742, which `main`
      reds on too). Read from inside `platform-web-0` while the stack was
      up, in the shape the runner fails on (no address on `eth0`, the public
      address on `eth1`, no default route): routes naming the uplink `0`, the
      only on-link `/32` is `10.30.1.1 dev eth1 proto dhcp` (the gateway,
      live), `ip route get 10.209.83.1` answers `via 10.30.1.1 dev eth1`,
      `ip neigh` empty, `resolvectl dns eth1: 1.1.1.1 10.30.1.1`, and the
      station reaches the published address. Not a controlled A/B: the guest's
      shape differed between the `main` run and this one (on `main` `eth0` was
      alive with its launch config and the station reached it by that door),
      and why is not established. Skipped: the full `mise run conformance`;
      the change is in the machine layer and no client suite of the matrix
      starts a runtime. A `workflow_dispatch` of `runtime-proof.yml` on this
      branch: https://github.com/stephrobert/feint/actions/runs/34111422372
      (verdict per job below, once it concludes).

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass". Not the full
      pass: the runtime leg and the stack gate, which are the runs this change
      reaches; see above
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: no API field
      is touched; `dns.nameservers` is an Incus network key
      (`incus network create --help`, network_ovn reference)

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit
- [x] The README's generated tables regenerated (`mise run docs:coverage`) —
      `feint docs --check` answers 0; nothing generated moved

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

- [x] Tested with `FEINT_VM=incus` (or `incus-vm`), not only with `--vm off`:
      `incus-ovn`, the mode the defect lives in; the bridge half is held by the
      test (a bridge names no resolver, its dnsmasq is on-link)
- [x] Nothing the emulator did not create was touched. Everything it creates is
      labelled, and `feint clean` sweeps exactly those
- [x] The run leaves nothing behind — checked, not assumed: `incus list` and
      `incus network list` after each of the four runtime runs (the leg, two
      stack gates, one Exoscale baseline): no `feint`/`fnt-` machine or
      network, only the station's own unrelated instance

## What was found on the way, and filed rather than folded in

- #741: an Exoscale machine on a bare interface wears `opn-fnt` while its
  plan claims no rule set; the verification guard reds the local runtime leg
  on it, on `main` as here.
- #740: the `runtime` job of `runtime-proof.yml` never runs
  `guard.sh verification`, so the nights never judged that claim.
- #742: under `incus-ovn` the stack gate reds at the reboot comparison on
  `platform-web-0`, on `main` as here, in two mirror shapes of the same two
  writers of `eth0`.
- #738, #739: found while verifying the release body against the code, not
  this change's subject.

## Related issues

Closes #697. Refs #660, #684, #693, #694, #695, #696, #736.
