### PR TITLE
fix(falsify): two specs carried a replace fragment that was not Go, so their mutation proved nothing (#720)

### DIFF
--- a/tools/falsify/specs/lifecycle-tells-the-truth.json
+++ b/tools/falsify/specs/lifecycle-tells-the-truth.json
@@ -57,7 +57,7 @@
       "label": "#549, the diagnosis: a guest that never finishes configuring its interface is no longer reported by the wait, so the failure an operator reads names the network rather than the machine and the device that could not be repaired",
       "file": "internal/core/machine/incus_ovn.go",
       "find": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil {\n\t\t\treturn errors.Join(routed, err)\n\t\t}",
-      "replace": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil && false {\n\t\t\treturn errors.Join(routed, err)ors.Join(routed, err)\n\t\t}",
+      "replace": "\t\tif err := d.waitForGuestInterface(ctx, machine, device); err != nil && false {\n\t\t\treturn errors.Join(routed, err)\n\t\t}",
       "test": "TestAGuestThatNeverConfiguresItsInterfaceIsReported"
     },
     {

--- a/tools/falsify/specs/public-address-migration.json
+++ b/tools/falsify/specs/public-address-migration.json
@@ -56,7 +56,7 @@
       "label": "a restarted machine is left waiting for a lease nobody offers, so it comes back with neither its private address nor its routes",
       "file": "internal/core/machine/incus_ovn.go",
       "find": "\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\treturn errors.Join(routed, err)\n\t\t}",
-      "replace": "\t\tif false {\n\t\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\t\treturn errors.Join(routed, err)ors.Join(routed, err)\n\t\t\t}\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\tif err := d.restorePinnedAddress(ctx, machine, device, devices.own[device]); err != nil {\n\t\t\t\treturn errors.Join(routed, err)\n\t\t\t}\n\t\t}",
       "test": "TestARestartedMachineGetsItsPinnedAddressBack"
     },
     {


### PR DESCRIPTION
# Summary

Two falsify specs on `main` carried a `replace` fragment that is not Go,
`errors.Join(routed, err)ors.Join(routed, err)`, in one mutation each of
`lifecycle-tells-the-truth.json` and `public-address-migration.json` (#720). A
mutant that does not build fails every test of its package, which reads exactly
like the guard being proven, and `falsify:lint` cannot see it: it checks that a
`find` fragment is present, not that a `replace` builds. So two guards of
`internal/core/machine` had a falsification recorded as run and not.

This is the repair alone: both fragments read `errors.Join(routed, err)`, and
both specs were replayed whole on 2026-09-07:

- `lifecycle-tells-the-truth.json`: 9 mutations, `compiled=yes`, `the test
  bit` on every one, including the repaired one ("#549, the diagnosis: a guest
  that never finishes configuring its interface is no longer reported by the
  wait…", `TestAGuestThatNeverConfiguresItsInterfaceIsReported` red);
- `public-address-migration.json`: 9 mutations, same verdict, including the
  repaired one ("a restarted machine is left waiting for a lease nobody
  offers…", `TestARestartedMachineGetsItsPinnedAddressBack` red).

`baseline: green` and `after restoration: green` on both, so the harness
measured the mutation and not its own breakage.

The mechanism that would refuse the next corrupted fragment (a lint that builds
each mutant, with the cost named) is the second half of #720 and belongs to
0.14.0 beside #737; deliberately not here.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`):
      the diff touches two JSON specs and no Go; `mise run prepush` ran on
      push, `falsify:lint` and `falsify:selftest` included
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider
- [x] `mise run testplan` was run, and what it printed was run — or this pull
      request names the run it skipped and why: the diff is two falsify
      specs; the runs that judge them are the two replays above,
      `mise run falsify -- tools/falsify/specs/<spec>.json`, both green with
      every mutation biting. No conformance leg reaches a spec file.

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": N/A for a
      spec file, nothing compiled into the emulator changes; the replays above
      are the run
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: no field;
      the fragment is the Go the source file carries at
      `internal/core/machine/incus_ovn.go`

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

N/A

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

N/A: the guards the two specs exercise live in the machine layer, but the
change is to the specs and the replay runs the package's unit tests, no
runtime.

## Related issues

Refs #720 (the repair half; the lint that builds each mutant stays open there
for 0.14.0). Found by #719's replay.
