### PR TITLE
fix(machine): the hot migration waits for the guest to lay the routed interface before it writes, as the restart path already did (#742)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -434,13 +434,25 @@ change ni l'un ni l'autre a sa place dans `git log`.
   après, en course avec la réapplication par systemd-networkd du netplan de
   l'invité sur le nouveau lien : networkd en dernier, la machine gardait
   l'adresse sur deux interfaces ; le pilote en dernier, elle n'en gardait
-  aucune sur `eth0` et pas de route par défaut. Les deux chemins passent
-  désormais par un seul ordre, celui que #674 énonçait pour un redémarrage :
-  la config de l'invité d'abord, le pilote ensuite, qui attend son tour. Ce
-  qu'ils produisent est délibérément inchangé, une interface routée sans
-  adresse portant la route par défaut par `169.254.0.1` ; savoir si c'est la
-  bonne forme relève de la moitié sortante de #695 et de l'ADR #726, et n'est
-  pas tranché ici. Le défaut est antérieur à v0.12.1 : le gate d'aujourd'hui
+  aucune sur `eth0` et pas de route par défaut. Un ordre a d'abord été
+  essayé et n'a pas tenu sur le runner : sondé à 100 ms à travers
+  l'attachement à chaud, le lien rebranché répond `Network File: n/a` pendant
+  150 ms avant que networkd ne l'apparie, ce qui se lit exactement comme
+  « personne ne gère ce lien », et tant que networkd possède la configuration
+  de l'interface, tout ordre du pilote est une course. Le pilote dit donc à
+  networkd, dans la configuration de networkd, de lâcher une interface routée
+  dont l'adresse a migré : un drop-in à côté de l'unité rendue par netplan
+  (`[Link] Unmanaged=yes`, le mécanisme que #702 emploie déjà pour le
+  résolveur), un rechargement, et l'attente de l'état que networkd rapporte,
+  `(unmanaged)`, avant de retirer l'adresse périmée et de poser les routes :
+  avant le re-plug sur le chemin à chaud, au premier boot après une migration
+  à froid sur le chemin de redémarrage, et à chaque boot suivant plus personne
+  que le pilote n'écrit l'interface. Un invité sans networkd est laissé
+  tranquille. Ce qui est produit est délibérément inchangé, une interface
+  routée sans adresse portant la route par défaut par `169.254.0.1` ; #742
+  change qui l'écrit, pas ce qui est écrit, et savoir si c'est la bonne forme
+  relève de la moitié sortante de #695 et de l'ADR #726, non tranché ici. Le
+  défaut est antérieur à v0.12.1 : le gate d'aujourd'hui
   pilotant un binaire construit depuis ce tag atteint l'étape et y échoue
   aussi, plus largement. La comparaison qui le trouve est postérieure à ce
   tag, donc aucune release antérieure n'a été mesurée sur cette étape.

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -418,6 +418,33 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Une machine dont l'adresse publique a migré sur sa NIC privée porte la
+  même forme avant et après le verbe de reboot : la migration à chaud attend
+  que l'invité ait posé l'interface routée avant d'écrire, comme le chemin de
+  redémarrage le faisait déjà** (#742). La comparaison de reboot du gate des
+  stacks (#671) rougissait sur `platform-web-0`, sur le runner comme sur la
+  station de l'auteur, et sous deux formes miroir : une fois `before: addr
+  eth0 203.0.113.4/32`, une fois `after: route 0.0.0.0/0 via 169.254.0.1 dev
+  eth0`. Sondé toutes les demi-secondes à travers le reboot le 2026-09-07, le
+  reboot lui-même était déterministe : netplan pose `eth0` 0,5 s après le
+  retour du conteneur, le pilote retire l'adresse périmée 2,2 s après, le
+  pilote pose la route par défaut 2,8 s après. Ce qui variait, c'était l'état
+  d'avant. La migration de #548 édite le device routé, ce qui le rebranche,
+  puis réparait l'interface aussitôt et supprimait l'adresse déplacée juste
+  après, en course avec la réapplication par systemd-networkd du netplan de
+  l'invité sur le nouveau lien : networkd en dernier, la machine gardait
+  l'adresse sur deux interfaces ; le pilote en dernier, elle n'en gardait
+  aucune sur `eth0` et pas de route par défaut. Les deux chemins passent
+  désormais par un seul ordre, celui que #674 énonçait pour un redémarrage :
+  la config de l'invité d'abord, le pilote ensuite, qui attend son tour. Ce
+  qu'ils produisent est délibérément inchangé, une interface routée sans
+  adresse portant la route par défaut par `169.254.0.1` ; savoir si c'est la
+  bonne forme relève de la moitié sortante de #695 et de l'ADR #726, et n'est
+  pas tranché ici. Le défaut est antérieur à v0.12.1 : le gate d'aujourd'hui
+  pilotant un binaire construit depuis ce tag atteint l'étape et y échoue
+  aussi, plus largement. La comparaison qui le trouve est postérieure à ce
+  tag, donc aucune release antérieure n'a été mesurée sur cette étape.
+
 - **Une machine qui porte une adresse publique et un réseau privé répond de
   nouveau sur son adresse publiée sous `incus-ovn` : le réseau nomme sa propre
   passerelle comme résolveur du bail** (#697). `runtime-proof` était rouge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,31 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A machine whose public address moved onto its private NIC carries the
+  same shape before and after the reboot verb: the hot migration waits for
+  the guest to lay the routed interface before it writes, as the restart path
+  already did** (#742). The stack gate's reboot comparison (#671) reddened on
+  `platform-web-0` on the runner as on the author's station, and in two
+  mirror shapes: once `before: addr eth0 203.0.113.4/32`, once `after: route
+  0.0.0.0/0 via 169.254.0.1 dev eth0`. Polled at half-second intervals across
+  the reboot on 2026-09-07, the reboot itself was deterministic: netplan lays
+  `eth0` 0.5 s after the container is back, the driver takes the stale
+  address off 2.2 s after, the driver lays the default route 2.8 s after.
+  What varied was the state before it. The migration of #548 edits the routed
+  device, which re-plugs it, then repaired the interface at once and deleted
+  the moved address right after, racing systemd-networkd's re-application of
+  the guest's own netplan to the new link: networkd last, the machine kept
+  the address on two interfaces; the driver last, it kept none on `eth0` and
+  no default route. Both paths now go through one order, the one #674 stated
+  for a restart: the guest's config first, the driver second, waiting its
+  turn. What they produce is deliberately unchanged, an addressless routed
+  interface carrying the default route through `169.254.0.1`; whether that is
+  the right shape is #695's outbound half and the ADR of #726, and is not
+  decided here. The defect is older than v0.12.1: today's gate driving a
+  binary built from that tag reaches the step and fails it too, by more. The
+  comparison that finds it is later than that tag, so no earlier release was
+  measured on this step.
+
 - **A machine holding a public address and a private network answers at its
   published address again under `incus-ovn`: the network names its own
   gateway as the lease's resolver** (#697). `runtime-proof` was red four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,12 +406,23 @@ what this project is judged on: **a response shape a client can observe**, and
   the moved address right after, racing systemd-networkd's re-application of
   the guest's own netplan to the new link: networkd last, the machine kept
   the address on two interfaces; the driver last, it kept none on `eth0` and
-  no default route. Both paths now go through one order, the one #674 stated
-  for a restart: the guest's config first, the driver second, waiting its
-  turn. What they produce is deliberately unchanged, an addressless routed
-  interface carrying the default route through `169.254.0.1`; whether that is
-  the right shape is #695's outbound half and the ADR of #726, and is not
-  decided here. The defect is older than v0.12.1: today's gate driving a
+  no default route. An order was tried first and did not hold on the runner:
+  polled at 100 ms across the hot attach, the re-plugged link answers
+  `Network File: n/a` for 150 ms before networkd matches it, which reads
+  exactly like "nobody manages this", and while networkd owns the interface's
+  configuration every order the driver takes is a race. So the driver now
+  tells networkd, in networkd's own configuration, to let go of a routed
+  interface whose address moved: a drop-in beside the unit netplan rendered
+  (`[Link] Unmanaged=yes`, the mechanism #702 already uses for the resolver),
+  a reload, and a wait for the state networkd reports, `(unmanaged)`, before
+  the stale address is taken off and the routes laid — before the re-plug on
+  the hot path, at the first boot after a cold migration on the restart path,
+  and at every boot after that nobody but the driver writes the interface. A
+  guest with no networkd is left alone. What is produced is deliberately
+  unchanged, an addressless routed interface carrying the default route
+  through `169.254.0.1`; #742 changes who writes it, not what is written, and
+  whether that is the right shape is #695's outbound half and the ADR of
+  #726, not decided here. The defect is older than v0.12.1: today's gate driving a
   binary built from that tag reaches the step and fails it too, by more. The
   comparison that finds it is later than that tag, so no earlier release was
   measured on this step.

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -207,7 +207,7 @@ func (d *Incus) routedNICCarrying(ctx context.Context, machine, address string) 
 // boot's netplan plus the restart path reconcile the guest. Asked once, before
 // the guest work, because the wait would otherwise poll a machine that will
 // never lay an interface for the whole of its budget.
-// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff and
+// TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug and
 // TestAColdMigrationDoesNotWaitForTheGuest fail without the two halves.
 //
 // Ownership before shape, and this call is why: safeName has said the name
@@ -231,34 +231,39 @@ func (d *Incus) releaseFromRoutedNIC(ctx context.Context, machine, device, addre
 			kept = append(kept, entry)
 		}
 	}
-	if _, err := d.setDevice(ctx, machine, device,
-		"ipv4.address="+strings.Join(kept, ",")); err != nil {
-		return fmt.Errorf("release %s from %s/%s: %w", address, machine, device, err)
-	}
-	m, found, err := d.Inspect(ctx, machine)
-	if err != nil {
-		return fmt.Errorf("read the state of %s after releasing %s: %w", machine, address, err)
-	}
-	if !found || !m.Running {
-		return nil
-	}
-	// What the device holds now, without a second read: the edit above is the
-	// only writer of ipv4.address on this NIC, and ipv4.routes it left alone.
+	// What the device will hold once released: the edit below is the only
+	// writer of ipv4.address on this NIC, and ipv4.routes it leaves alone.
 	after := map[string]string{
 		"ipv4.address": strings.Join(kept, ","),
 		"ipv4.routes":  devices.own[device]["ipv4.routes"],
 	}
-	// Whether anyone in the guest will lay the re-plugged link: systemd-networkd
-	// does when a unit matches it (netplan's, on the images measured), and the
-	// wait is for that write. A guest that names no unit — no networkd, an
-	// unmanaged link — has no writer to wait for, and the re-plug left the
-	// interface bare for good.
-	iface, err := d.guestInterface(ctx, machine, device)
+	m, found, err := d.Inspect(ctx, machine)
 	if err != nil {
-		return err
+		return fmt.Errorf("read the state of %s before releasing %s: %w", machine, address, err)
 	}
-	guestWrites := d.guestNetworkUnit(ctx, machine, iface) != ""
-	return d.reconcileRoutedInterface(ctx, machine, device, after, guestWrites)
+	running := found && m.Running
+	// BEFORE the edit, on a running machine, because the edit re-plugs the
+	// interface and the new link is what networkd would lay the stale config
+	// on (#742). Asked now, the guest names the unit it has managed the
+	// interface with since the boot; asked after the re-plug, the same guest
+	// answers `n/a` for the 150 ms before networkd matches the new link, which
+	// reads exactly like "nobody manages this" and was measured to be the
+	// window the driver wrote first in. With the interface unmanaged before it
+	// is re-plugged, the new link is nobody's from its first moment, and the
+	// reconciliation after the edit finds nothing to race.
+	if running && routedDeviceCarriesNothing(after) {
+		if _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {
+			return err
+		}
+	}
+	if _, err := d.setDevice(ctx, machine, device,
+		"ipv4.address="+strings.Join(kept, ",")); err != nil {
+		return fmt.Errorf("release %s from %s/%s: %w", address, machine, device, err)
+	}
+	if !running {
+		return nil
+	}
+	return d.reconcileRoutedInterface(ctx, machine, device, after)
 }
 
 // mustOwn refuses to touch a network the emulator did not create. The label is

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -190,12 +190,25 @@ func (d *Incus) routedNICCarrying(ctx context.Context, machine, address string) 
 //
 // What it costs and what it restores. Setting ipv4.address on a live routed
 // NIC re-plugs the device, exactly as an ipv4.routes edit does, so the guest
-// interface comes back down and bare; repairRoutedInterface puts back what the
-// device still declares, which is every address but the one being moved. The
-// explicit delete afterwards covers the case where the edit did *not* re-plug
-// — a stopped machine, a runtime that updates in place — because an address
-// left inside the guest on an interface the host no longer routes is a machine
-// answering ARP for something nothing delivers.
+// interface comes back down and bare — and then the guest's own netplan lays
+// it again, with the launch address the device just let go of. The driver
+// goes second, on the same terms as after a boot (reconcileRoutedInterface,
+// #674, #742): it waits for the guest's config to have laid the interface,
+// takes off every address the device no longer pins or routes, and puts back
+// what it does. Until #742 the repair ran the moment the edit returned and the
+// delete right after, racing networkd on the re-plugged link; which of the two
+// wrote last decided whether the machine carried the moved address on two
+// interfaces or on one, and the reboot comparison of #671 found the difference
+// on every run. An address left inside the guest on an interface the host no
+// longer routes is a machine answering ARP for something nothing delivers,
+// which is why the release is not left to the re-plug alone.
+//
+// A stopped machine takes no exec: the device key is set cold, and the next
+// boot's netplan plus the restart path reconcile the guest. Asked once, before
+// the guest work, because the wait would otherwise poll a machine that will
+// never lay an interface for the whole of its budget.
+// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff and
+// TestAColdMigrationDoesNotWaitForTheGuest fail without the two halves.
 //
 // Ownership before shape, and this call is why: safeName has said the name
 // could be a command argument, never that the instance is ours, and this
@@ -222,13 +235,20 @@ func (d *Incus) releaseFromRoutedNIC(ctx context.Context, machine, device, addre
 		"ipv4.address="+strings.Join(kept, ",")); err != nil {
 		return fmt.Errorf("release %s from %s/%s: %w", address, machine, device, err)
 	}
-	if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
-		return err
+	m, found, err := d.Inspect(ctx, machine)
+	if err != nil {
+		return fmt.Errorf("read the state of %s after releasing %s: %w", machine, address, err)
 	}
-	// Tolerant on purpose: the re-plug usually took it, a stopped machine
-	// holds no live address, and "cannot find" is the outcome asked for.
-	_, _ = d.run(ctx, "exec", machine, "--", "ip", "address", "del", address+"/32", "dev", device)
-	return nil
+	if !found || !m.Running {
+		return nil
+	}
+	// What the device holds now, without a second read: the edit above is the
+	// only writer of ipv4.address on this NIC, and ipv4.routes it left alone.
+	after := map[string]string{
+		"ipv4.address": strings.Join(kept, ","),
+		"ipv4.routes":  devices.own[device]["ipv4.routes"],
+	}
+	return d.reconcileRoutedInterface(ctx, machine, device, after)
 }
 
 // mustOwn refuses to touch a network the emulator did not create. The label is

--- a/internal/core/machine/incus_address.go
+++ b/internal/core/machine/incus_address.go
@@ -248,7 +248,17 @@ func (d *Incus) releaseFromRoutedNIC(ctx context.Context, machine, device, addre
 		"ipv4.address": strings.Join(kept, ","),
 		"ipv4.routes":  devices.own[device]["ipv4.routes"],
 	}
-	return d.reconcileRoutedInterface(ctx, machine, device, after)
+	// Whether anyone in the guest will lay the re-plugged link: systemd-networkd
+	// does when a unit matches it (netplan's, on the images measured), and the
+	// wait is for that write. A guest that names no unit — no networkd, an
+	// unmanaged link — has no writer to wait for, and the re-plug left the
+	// interface bare for good.
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil {
+		return err
+	}
+	guestWrites := d.guestNetworkUnit(ctx, machine, iface) != ""
+	return d.reconcileRoutedInterface(ctx, machine, device, after, guestWrites)
 }
 
 // mustOwn refuses to touch a network the emulator did not create. The label is

--- a/internal/core/machine/incus_address_replay_test.go
+++ b/internal/core/machine/incus_address_replay_test.go
@@ -54,6 +54,10 @@ func TestAPublicAddressMovesOntoTheFilteredNIC(t *testing.T) {
 		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
 		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
 		"network get " + DefaultUplinkName + " ipv4.routes": "",
+		// A running machine whose guest has laid eth0, so the release waits
+		// for nothing (#742); the order under test is the device's.
+		"list srv --format json": `[{"name":"srv","status":"Running","state":{"network":{}}}]`,
+		"addr show dev eth0":     "2: eth0    inet 203.0.113.4/32 scope global eth0\n",
 	}}
 	d := newFakeDriver(f)
 	d.OVN = true
@@ -98,6 +102,8 @@ func TestAPublicAddressMovesOntoTheFilteredNICInBridgeMode(t *testing.T) {
 		"/1.0/instances/srv":                           routedAndPrivate,
 		"network get fnt-368798629f8 user." + LabelKey: "feint\n",
 		"config device get srv eth1 ipv4.routes":       "",
+		"list srv --format json":                       `[{"name":"srv","status":"Running","state":{"network":{}}}]`,
+		"addr show dev eth0":                           "2: eth0    inet 203.0.113.4/32 scope global eth0\n",
 	}}
 	d := newFakeDriver(f)
 

--- a/internal/core/machine/incus_address_replay_test.go
+++ b/internal/core/machine/incus_address_replay_test.go
@@ -189,6 +189,11 @@ func TestMigrationRefusesAnInstanceTheEmulatorDidNotCreate(t *testing.T) {
 				// The instance carries no label of ours, which is what the
 				// fake's default answer would otherwise supply.
 				"config get production-database user." + LabelKey: "\n",
+				// And it is running, so that without the guard the migration
+				// goes all the way to the device edit this test forbids,
+				// rather than dying on an unreadable state and passing over a
+				// neutralised guard (#742's replay found exactly that).
+				"list production-database --format json": `[{"name":"production-database","status":"Running","state":{"network":{}}}]`,
 			}}
 			d := newFakeDriver(f)
 			d.OVN = ovn
@@ -222,6 +227,9 @@ func TestAMigrationIsNotStartedForANetworkTheEmulatorDoesNotOwn(t *testing.T) {
 				"/1.0/instances/srv": routedAndPrivate,
 				// The network carries no label of ours.
 				"network get fnt-368798629f8 user." + LabelKey: "\n",
+				// The machine is running, so that without the guard the release
+				// reaches the device edit this test forbids (see the test above).
+				"list srv --format json": `[{"name":"srv","status":"Running","state":{"network":{}}}]`,
 			}}
 			d := newFakeDriver(f)
 			d.OVN = ovn

--- a/internal/core/machine/incus_migration_order_test.go
+++ b/internal/core/machine/incus_migration_order_test.go
@@ -8,28 +8,10 @@ import (
 	"time"
 )
 
-// The two writers of a routed interface, held to one order on the hot path as
-// well as after a boot (#742).
-//
-// The guest's own netplan, rendered once at the first boot (routedNetworkConfig),
-// declares eth0 with the launch address and the default route through
-// 169.254.0.1, and systemd-networkd re-applies it every time the interface
-// appears: at a boot, and at the re-plug an ipv4.address edit causes. The
-// driver's migration (#548) edited the device, repaired the interface at once,
-// then deleted the moved address, and so raced networkd on a link it had just
-// re-plugged. Measured 2026-09-07 on platform-web-0 of the Scaleway example
-// stack under `--vm incus-ovn`, the same reboot verb producing two different
-// "before" shapes on two runs:
-//
-//	networkd first, then the driver's del:  eth0 bare, no default route
-//	the driver's del first, then networkd:  eth0 203.0.113.4/32 + default via 169.254.0.1
-//
-// while the restart path, which waits for the guest to lay the interface
-// before it writes (#674), always produced eth0 bare + default via 169.254.0.1,
-// polled at half-second intervals: netplan at t+0.5 s after the container was
-// back, the driver's release at t+2.2 s, the driver's default route at t+2.8 s.
-// So the reboot comparison of #671 found a difference on every run, in one
-// direction or the other, and the difference was never the reboot's.
+// A routed interface whose address moved is taken away from the guest's own
+// network stack before the driver writes it (#742); incus_unmanaged.go carries
+// the measurement. The tests here hold the hot door, releaseFromRoutedNIC;
+// incus_routed_boot_test.go holds the boot door.
 
 // migratedRoutedAndPrivate is routedAndPrivate after the device edit: eth0
 // routed and addressless, eth1 carrying the external route (migratedRouted is
@@ -49,35 +31,54 @@ const migratedRoutedAndPrivate = `{
   }
 }`
 
-// managedByNetworkd is what `networkctl status eth0` answers on the images
-// measured: netplan rendered a unit for the launch interface, and networkd
-// re-applies it to the link every time the link appears.
-const managedByNetworkd = "● 2: eth0\n             Network File: /run/systemd/network/10-netplan-eth0.network\n"
+// What `networkctl status eth0` answers on the images measured, at the three
+// moments that matter: managed by the unit netplan rendered, still busy after
+// the reload that carried the unmanaged drop-in, and let go of.
+const (
+	managedByNetworkd   = "● 2: eth0\n             Network File: /run/systemd/network/10-netplan-eth0.network\n                   State: routable (configured)\n"
+	stillConfiguring    = "● 2: eth0\n             Network File: /run/systemd/network/10-netplan-eth0.network\n                   State: routable (configuring)\n"
+	letGoByNetworkd     = "● 2: eth0\n             Network File: n/a\n                   State: off (unmanaged)\n"
+	noNetworkctlAtAll   = "incus exec: Error: networkctl: not found"
+	statusReadsToSettle = 3
+)
 
-// migrationRuntime is a running machine whose guest lays eth0 from its own
-// config only on the third read: the two reads before that are the window
-// in which networkd has not written yet, which is exactly where the old order
-// deleted an address that was not there and repaired a link networkd was
-// about to overwrite. unit is what the guest answers about the link's writer;
-// empty means an image with no networkctl at all.
-func migrationRuntime(status, unit string, laysAfter int) *fakeRuntime {
+// migrationRuntime is a running machine on the hot door. Before the device
+// edit the guest names the unit that manages eth0; after `networkctl reload`
+// it answers (configuring) for statusReadsToSettle-1 reads and (unmanaged)
+// from then on, which is networkd finishing what the driver asked of it. The
+// re-plugged eth0 answers with the launch address on it, the write networkd
+// would have made before it was told to let go, so the release has something
+// to take off. unit is what the guest answers before the reload; empty means
+// an image with no networkctl at all.
+func migrationRuntime(status, unit string) *fakeRuntime {
 	f := &fakeRuntime{answers: map[string]string{
 		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
 		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
 		"network get " + DefaultUplinkName + " ipv4.routes": "",
 	}}
 	released := false
-	reads := 0
+	reloaded := false
+	statusReads := 0
 	f.hook = func(_ int, args []string) ([]byte, error, bool) {
 		key := strings.Join(args, " ")
 		switch {
 		case args[0] == "list":
 			return []byte(`[{"name":"srv","status":"` + status + `","state":{"network":{}}}]`), nil, true
+		case strings.Contains(key, "networkctl reload"):
+			reloaded = true
+			return nil, nil, true
 		case strings.Contains(key, "networkctl status eth0"):
 			if unit == "" {
-				return nil, errors.New("incus exec: Error: networkctl: not found"), true
+				return nil, errors.New(noNetworkctlAtAll), true
 			}
-			return []byte(unit), nil, true
+			if !reloaded {
+				return []byte(unit), nil, true
+			}
+			statusReads++
+			if statusReads < statusReadsToSettle {
+				return []byte(stillConfiguring), nil, true
+			}
+			return []byte(letGoByNetworkd), nil, true
 		case args[0] == "query" && strings.HasSuffix(key, "/1.0/instances/srv"):
 			if released {
 				return []byte(migratedRoutedAndPrivate), nil, true
@@ -87,30 +88,39 @@ func migrationRuntime(status, unit string, laysAfter int) *fakeRuntime {
 			released = true
 			return nil, nil, true
 		case strings.Contains(key, "addr show dev eth0"):
-			reads++
-			if reads >= laysAfter {
-				return []byte("2: eth0    inet 203.0.113.4/32 scope global eth0\n"), nil, true
-			}
-			return []byte(""), nil, true
+			return []byte("2: eth0    inet 203.0.113.4/32 scope global eth0\n"), nil, true
 		}
 		return nil, nil, false
 	}
 	return f
 }
 
-// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff: after the
-// device edit re-plugs eth0, the driver reads the interface until the guest's
-// own config has laid it, takes the moved address off, and only then lays the
-// default route — the order reconcileRoutedNICs already holds after a boot.
-// Without the wait, the third read never happens and the deletion finds
-// nothing; with the repair before the release, the default route the driver
-// lays is the one the deletion takes away.
-func TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff(t *testing.T) {
-	f := migrationRuntime("Running", managedByNetworkd, 3)
+// statusReadsBetween counts the `networkctl status eth0` asks the driver made
+// between two positions of the command log.
+func statusReadsBetween(f *fakeRuntime, from, to int) int {
+	n := 0
+	for i, cmd := range f.commands() {
+		if i > from && (to < 0 || i < to) && strings.Contains(cmd, "networkctl status eth0") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug: the drop-in is
+// written and networkd reloaded BEFORE the device edit that re-plugs eth0, so
+// the new link is nobody's from its first moment; the driver then reads
+// networkd's state until it says so, and only after that takes the stale
+// address off and lays the default route. Written the other way — asked after
+// the re-plug — the same guest answers `n/a` for the 150 ms before networkd
+// matches the new link, which reads like "nobody manages this", and the driver
+// wrote first in exactly that window on the runner (#742).
+func TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug(t *testing.T) {
+	f := migrationRuntime("Running", managedByNetworkd)
 	d := newFakeDriver(f)
 	d.OVN = true
-	d.routePoll = time.Millisecond
-	d.routeBudget = time.Second
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = time.Second
 
 	if err := d.RouteAddress(context.Background(), AddressSpec{
 		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
@@ -118,43 +128,92 @@ func TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff(t *testing.
 		t.Fatalf("migrate: %v", err)
 	}
 
-	release := step(f, "config device set srv eth0 ipv4.address=")
+	dropIn := step(f, unmanagedDropIn)
+	set := step(f, "config device set srv eth0 ipv4.address=")
 	del := step(f, "ip address del 203.0.113.4/32 dev eth0")
 	route := step(f, "ip route add default via 169.254.0.1 dev eth0")
-	reads := f.matching("addr show dev eth0")
+	reload := -1
+	for i, cmd := range f.commands() {
+		if i > dropIn && strings.Contains(cmd, "networkctl reload") {
+			reload = i
+			break
+		}
+	}
 	switch {
-	case release < 0:
+	case set < 0:
 		t.Fatalf("the address was never released from the routed NIC:\n%s", strings.Join(f.commands(), "\n"))
+	case dropIn < 0:
+		t.Fatalf("networkd was never told to let go of eth0, so it lays the launch config on the re-plugged link "+
+			"whenever it wins the race (#742):\n%s", strings.Join(f.commands(), "\n"))
+	case !strings.Contains(f.commands()[dropIn], "Unmanaged=yes"):
+		t.Fatalf("the drop-in does not say Unmanaged=yes: %s", f.commands()[dropIn])
+	case dropIn > set:
+		t.Errorf("networkd was told to let go only after the re-plug, inside the window where the new link "+
+			"answers n/a and networkd is about to write it (#742):\n%s", strings.Join(f.commands(), "\n"))
+	case reload < 0 || reload > set:
+		t.Errorf("the drop-in was written and networkd was not told to read it before the re-plug:\n%s",
+			strings.Join(f.commands(), "\n"))
+	case statusReadsBetween(f, reload, set) < statusReadsToSettle:
+		t.Errorf("the driver went on before networkd reported the link unmanaged (%d state read(s) after the "+
+			"reload): a state it provoked, not waited for:\n%s",
+			statusReadsBetween(f, reload, set), strings.Join(f.commands(), "\n"))
 	case del < 0:
-		t.Fatalf("the moved address was never taken off the guest's routed interface, so the guest "+
-			"answers ARP for an address the host no longer routes to it:\n%s", strings.Join(f.commands(), "\n"))
-	case len(reads) < 3:
-		t.Fatalf("the driver read eth0 %d time(s) and did not wait for the guest's own config to lay it "+
-			"(#742): its writes race networkd's on a link it just re-plugged:\n%s",
-			len(reads), strings.Join(f.commands(), "\n"))
-	case del < release:
+		t.Errorf("the moved address was never taken off the guest's routed interface:\n%s",
+			strings.Join(f.commands(), "\n"))
+	case del < set:
 		t.Errorf("the address was taken off the guest before the device let go of it:\n%s",
 			strings.Join(f.commands(), "\n"))
-	case route >= 0 && route < del:
-		t.Errorf("the default route was laid before the stale address was taken off, and the deletion "+
-			"takes the route with it (#742):\n%s", strings.Join(f.commands(), "\n"))
 	case route < 0:
+		t.Errorf("the routed interface was left without its default route through %s:\n%s",
+			routedNextHop, strings.Join(f.commands(), "\n"))
+	case route < del:
+		t.Errorf("the default route was laid before the stale address was taken off, and the deletion "+
+			"takes the route with it:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestAGuestWithoutNetworkdIsLeftAloneByTheMigration: an image with no
+// networkd (Alpine, an ifupdown Debian) lays its interfaces at boot and never
+// again, so nobody is going to write the re-plugged link, there is no unit to
+// write a drop-in beside, and the driver takes off what the re-plug left and
+// lays its routes without asking anything else of the guest.
+func TestAGuestWithoutNetworkdIsLeftAloneByTheMigration(t *testing.T) {
+	f := migrationRuntime("Running", "")
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if got := f.matching(unmanagedDropIn); len(got) != 0 {
+		t.Errorf("a drop-in was written for a guest that has no networkd to read it:\n%s", strings.Join(got, "\n"))
+	}
+	if step(f, "ip address del 203.0.113.4/32 dev eth0") < 0 {
+		t.Errorf("the moved address was never taken off the guest's routed interface:\n%s",
+			strings.Join(f.commands(), "\n"))
+	}
+	if step(f, "ip route add default via 169.254.0.1 dev eth0") < 0 {
 		t.Errorf("the routed interface was left without its default route through %s:\n%s",
 			routedNextHop, strings.Join(f.commands(), "\n"))
 	}
 }
 
 // TestAColdMigrationDoesNotWaitForTheGuest: the ordinary Terraform order edits
-// the device of a stopped machine. There is no guest to wait for, nothing to
-// take off, and a wait that polled a stopped machine to its budget would hold
-// every cold attach for a minute and a half. The device is set, and the next
-// boot's netplan plus the restart path (reconcileRoutedNICs) do the rest.
+// the device of a stopped machine. There is no guest to tell, nothing to take
+// off, and nothing to wait for. The device is set, and the next boot's restart
+// path (reconcileRoutedNICs) does the rest, drop-in included.
 func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
-	f := migrationRuntime("Stopped", managedByNetworkd, 3)
+	f := migrationRuntime("Stopped", managedByNetworkd)
 	d := newFakeDriver(f)
 	d.OVN = true
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
 	d.routePoll = time.Millisecond
-	d.routeBudget = 50 * time.Millisecond
+	d.routeBudget = 20 * time.Millisecond
 
 	if err := d.RouteAddress(context.Background(), AddressSpec{
 		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
@@ -164,20 +223,19 @@ func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
 	if step(f, "config device set srv eth0 ipv4.address=") < 0 {
 		t.Fatalf("the address was never released from the routed NIC:\n%s", strings.Join(f.commands(), "\n"))
 	}
-	if got := f.matching("addr show dev eth0"); len(got) != 0 {
-		t.Errorf("a stopped machine was polled %d time(s) for an interface no guest will lay:\n%s",
-			len(got), strings.Join(f.commands(), "\n"))
+	if got := f.matching(unmanagedDropIn); len(got) != 0 {
+		t.Errorf("a stopped machine was written a drop-in:\n%s", strings.Join(got, "\n"))
 	}
 	// The device set settles the interface it set and the OVN half of the move
 	// runs its own guest step, both tolerant of a stopped machine as they
 	// always were; what must not run is the routed interface's reconciliation,
-	// which is the driver writing addresses and routes on eth0.
+	// which is the driver reading and writing addresses and routes on eth0.
 	var touched []string
 	for _, cmd := range f.matching("exec srv") {
 		if !strings.Contains(cmd, "eth0") {
 			continue
 		}
-		for _, write := range []string{"ip address", "ip route", "ip link"} {
+		for _, write := range []string{"ip address", "ip route", "ip link", "addr show"} {
 			if strings.Contains(cmd, write) {
 				touched = append(touched, cmd)
 				break
@@ -187,36 +245,5 @@ func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
 	if len(touched) != 0 {
 		t.Errorf("a stopped machine was told to reconfigure a routed interface it does not have up:\n%s",
 			strings.Join(touched, "\n"))
-	}
-}
-
-// TestAHotMigrationOnALinkNobodyManagesDoesNotWait: an image with no
-// systemd-networkd (Alpine, an ifupdown Debian) lays its interfaces at boot and
-// never again, so after the re-plug nobody is going to write eth0, and a wait
-// for that write would cost a hot address attach the whole budget — #694's
-// shape, a permanent case read as a transient one. The guest is asked once
-// whether the link has a writer, and with none the driver reads the interface
-// once, for the release, and moves on.
-func TestAHotMigrationOnALinkNobodyManagesDoesNotWait(t *testing.T) {
-	f := migrationRuntime("Running", "", 1000)
-	d := newFakeDriver(f)
-	d.OVN = true
-	d.routePoll = time.Millisecond
-	d.routeBudget = 200 * time.Millisecond
-	d.resolverPoll = time.Millisecond
-	d.resolverWait = 20 * time.Millisecond
-
-	if err := d.RouteAddress(context.Background(), AddressSpec{
-		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
-	}); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if reads := f.matching("addr show dev eth0"); len(reads) > 1 {
-		t.Errorf("a link nobody manages was polled %d time(s) for an address no guest will lay (#742):\n%s",
-			len(reads), strings.Join(f.commands(), "\n"))
-	}
-	if step(f, "ip route add default via 169.254.0.1 dev eth0") < 0 {
-		t.Errorf("the routed interface was left without its default route through %s:\n%s",
-			routedNextHop, strings.Join(f.commands(), "\n"))
 	}
 }

--- a/internal/core/machine/incus_migration_order_test.go
+++ b/internal/core/machine/incus_migration_order_test.go
@@ -1,0 +1,179 @@
+package machine
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The two writers of a routed interface, held to one order on the hot path as
+// well as after a boot (#742).
+//
+// The guest's own netplan, rendered once at the first boot (routedNetworkConfig),
+// declares eth0 with the launch address and the default route through
+// 169.254.0.1, and systemd-networkd re-applies it every time the interface
+// appears: at a boot, and at the re-plug an ipv4.address edit causes. The
+// driver's migration (#548) edited the device, repaired the interface at once,
+// then deleted the moved address, and so raced networkd on a link it had just
+// re-plugged. Measured 2026-09-07 on platform-web-0 of the Scaleway example
+// stack under `--vm incus-ovn`, the same reboot verb producing two different
+// "before" shapes on two runs:
+//
+//	networkd first, then the driver's del:  eth0 bare, no default route
+//	the driver's del first, then networkd:  eth0 203.0.113.4/32 + default via 169.254.0.1
+//
+// while the restart path, which waits for the guest to lay the interface
+// before it writes (#674), always produced eth0 bare + default via 169.254.0.1,
+// polled at half-second intervals: netplan at t+0.5 s after the container was
+// back, the driver's release at t+2.2 s, the driver's default route at t+2.8 s.
+// So the reboot comparison of #671 found a difference on every run, in one
+// direction or the other, and the difference was never the reboot's.
+
+// migratedRoutedAndPrivate is routedAndPrivate after the device edit: eth0
+// routed and addressless, eth1 carrying the external route (migratedRouted is
+// the same shape for another machine's address). The fixture the migration
+// reads BEFORE its edit is routedAndPrivate; this is what the runtime answers
+// after it, so a repair that re-reads the device sees what the device holds.
+const migratedRoutedAndPrivate = `{
+  "devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10",
+             "ipv4.routes.external": "203.0.113.4/32"}
+  },
+  "expanded_devices": {
+    "eth0": {"type": "nic", "nictype": "routed", "ipv4.host_address": "169.254.0.1"},
+    "eth1": {"type": "nic", "network": "fnt-368798629f8", "ipv4.address": "10.30.1.10",
+             "ipv4.routes.external": "203.0.113.4/32"}
+  }
+}`
+
+// migrationRuntime is a running machine whose guest lays eth0 from its own
+// config only on the third read: the two reads before that are the window
+// in which networkd has not written yet, which is exactly where the old order
+// deleted an address that was not there and repaired a link networkd was
+// about to overwrite.
+func migrationRuntime(status string, laysAfter int) *fakeRuntime {
+	f := &fakeRuntime{answers: map[string]string{
+		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
+		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
+		"network get " + DefaultUplinkName + " ipv4.routes": "",
+	}}
+	released := false
+	reads := 0
+	f.hook = func(_ int, args []string) ([]byte, error, bool) {
+		key := strings.Join(args, " ")
+		switch {
+		case args[0] == "list":
+			return []byte(`[{"name":"srv","status":"` + status + `","state":{"network":{}}}]`), nil, true
+		case args[0] == "query" && strings.HasSuffix(key, "/1.0/instances/srv"):
+			if released {
+				return []byte(migratedRoutedAndPrivate), nil, true
+			}
+			return []byte(routedAndPrivate), nil, true
+		case strings.HasPrefix(key, "config device set srv eth0 ipv4.address="):
+			released = true
+			return nil, nil, true
+		case strings.Contains(key, "addr show dev eth0"):
+			reads++
+			if reads >= laysAfter {
+				return []byte("2: eth0    inet 203.0.113.4/32 scope global eth0\n"), nil, true
+			}
+			return []byte(""), nil, true
+		}
+		return nil, nil, false
+	}
+	return f
+}
+
+// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff: after the
+// device edit re-plugs eth0, the driver reads the interface until the guest's
+// own config has laid it, takes the moved address off, and only then lays the
+// default route — the order reconcileRoutedNICs already holds after a boot.
+// Without the wait, the third read never happens and the deletion finds
+// nothing; with the repair before the release, the default route the driver
+// lays is the one the deletion takes away.
+func TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff(t *testing.T) {
+	f := migrationRuntime("Running", 3)
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.routePoll = time.Millisecond
+	d.routeBudget = time.Second
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	release := step(f, "config device set srv eth0 ipv4.address=")
+	del := step(f, "ip address del 203.0.113.4/32 dev eth0")
+	route := step(f, "ip route add default via 169.254.0.1 dev eth0")
+	reads := f.matching("addr show dev eth0")
+	switch {
+	case release < 0:
+		t.Fatalf("the address was never released from the routed NIC:\n%s", strings.Join(f.commands(), "\n"))
+	case del < 0:
+		t.Fatalf("the moved address was never taken off the guest's routed interface, so the guest "+
+			"answers ARP for an address the host no longer routes to it:\n%s", strings.Join(f.commands(), "\n"))
+	case len(reads) < 3:
+		t.Fatalf("the driver read eth0 %d time(s) and did not wait for the guest's own config to lay it "+
+			"(#742): its writes race networkd's on a link it just re-plugged:\n%s",
+			len(reads), strings.Join(f.commands(), "\n"))
+	case del < release:
+		t.Errorf("the address was taken off the guest before the device let go of it:\n%s",
+			strings.Join(f.commands(), "\n"))
+	case route >= 0 && route < del:
+		t.Errorf("the default route was laid before the stale address was taken off, and the deletion "+
+			"takes the route with it (#742):\n%s", strings.Join(f.commands(), "\n"))
+	case route < 0:
+		t.Errorf("the routed interface was left without its default route through %s:\n%s",
+			routedNextHop, strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestAColdMigrationDoesNotWaitForTheGuest: the ordinary Terraform order edits
+// the device of a stopped machine. There is no guest to wait for, nothing to
+// take off, and a wait that polled a stopped machine to its budget would hold
+// every cold attach for a minute and a half. The device is set, and the next
+// boot's netplan plus the restart path (reconcileRoutedNICs) do the rest.
+func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
+	f := migrationRuntime("Stopped", 3)
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.routePoll = time.Millisecond
+	d.routeBudget = 50 * time.Millisecond
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if step(f, "config device set srv eth0 ipv4.address=") < 0 {
+		t.Fatalf("the address was never released from the routed NIC:\n%s", strings.Join(f.commands(), "\n"))
+	}
+	if got := f.matching("addr show dev eth0"); len(got) != 0 {
+		t.Errorf("a stopped machine was polled %d time(s) for an interface no guest will lay:\n%s",
+			len(got), strings.Join(f.commands(), "\n"))
+	}
+	// The device set settles the interface it set and the OVN half of the move
+	// runs its own guest step, both tolerant of a stopped machine as they
+	// always were; what must not run is the routed interface's reconciliation,
+	// which is the driver writing addresses and routes on eth0.
+	var touched []string
+	for _, cmd := range f.matching("exec srv") {
+		if !strings.Contains(cmd, "eth0") {
+			continue
+		}
+		for _, write := range []string{"ip address", "ip route", "ip link"} {
+			if strings.Contains(cmd, write) {
+				touched = append(touched, cmd)
+				break
+			}
+		}
+	}
+	if len(touched) != 0 {
+		t.Errorf("a stopped machine was told to reconfigure a routed interface it does not have up:\n%s",
+			strings.Join(touched, "\n"))
+	}
+}

--- a/internal/core/machine/incus_migration_order_test.go
+++ b/internal/core/machine/incus_migration_order_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -48,12 +49,18 @@ const migratedRoutedAndPrivate = `{
   }
 }`
 
+// managedByNetworkd is what `networkctl status eth0` answers on the images
+// measured: netplan rendered a unit for the launch interface, and networkd
+// re-applies it to the link every time the link appears.
+const managedByNetworkd = "● 2: eth0\n             Network File: /run/systemd/network/10-netplan-eth0.network\n"
+
 // migrationRuntime is a running machine whose guest lays eth0 from its own
 // config only on the third read: the two reads before that are the window
 // in which networkd has not written yet, which is exactly where the old order
 // deleted an address that was not there and repaired a link networkd was
-// about to overwrite.
-func migrationRuntime(status string, laysAfter int) *fakeRuntime {
+// about to overwrite. unit is what the guest answers about the link's writer;
+// empty means an image with no networkctl at all.
+func migrationRuntime(status, unit string, laysAfter int) *fakeRuntime {
 	f := &fakeRuntime{answers: map[string]string{
 		"network get fnt-368798629f8 user." + LabelKey:      "feint\n",
 		"network get fnt-368798629f8 ipv4.address":          "10.30.1.1/24\n",
@@ -66,6 +73,11 @@ func migrationRuntime(status string, laysAfter int) *fakeRuntime {
 		switch {
 		case args[0] == "list":
 			return []byte(`[{"name":"srv","status":"` + status + `","state":{"network":{}}}]`), nil, true
+		case strings.Contains(key, "networkctl status eth0"):
+			if unit == "" {
+				return nil, errors.New("incus exec: Error: networkctl: not found"), true
+			}
+			return []byte(unit), nil, true
 		case args[0] == "query" && strings.HasSuffix(key, "/1.0/instances/srv"):
 			if released {
 				return []byte(migratedRoutedAndPrivate), nil, true
@@ -94,7 +106,7 @@ func migrationRuntime(status string, laysAfter int) *fakeRuntime {
 // nothing; with the repair before the release, the default route the driver
 // lays is the one the deletion takes away.
 func TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff(t *testing.T) {
-	f := migrationRuntime("Running", 3)
+	f := migrationRuntime("Running", managedByNetworkd, 3)
 	d := newFakeDriver(f)
 	d.OVN = true
 	d.routePoll = time.Millisecond
@@ -138,7 +150,7 @@ func TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff(t *testing.
 // every cold attach for a minute and a half. The device is set, and the next
 // boot's netplan plus the restart path (reconcileRoutedNICs) do the rest.
 func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
-	f := migrationRuntime("Stopped", 3)
+	f := migrationRuntime("Stopped", managedByNetworkd, 3)
 	d := newFakeDriver(f)
 	d.OVN = true
 	d.routePoll = time.Millisecond
@@ -175,5 +187,36 @@ func TestAColdMigrationDoesNotWaitForTheGuest(t *testing.T) {
 	if len(touched) != 0 {
 		t.Errorf("a stopped machine was told to reconfigure a routed interface it does not have up:\n%s",
 			strings.Join(touched, "\n"))
+	}
+}
+
+// TestAHotMigrationOnALinkNobodyManagesDoesNotWait: an image with no
+// systemd-networkd (Alpine, an ifupdown Debian) lays its interfaces at boot and
+// never again, so after the re-plug nobody is going to write eth0, and a wait
+// for that write would cost a hot address attach the whole budget — #694's
+// shape, a permanent case read as a transient one. The guest is asked once
+// whether the link has a writer, and with none the driver reads the interface
+// once, for the release, and moves on.
+func TestAHotMigrationOnALinkNobodyManagesDoesNotWait(t *testing.T) {
+	f := migrationRuntime("Running", "", 1000)
+	d := newFakeDriver(f)
+	d.OVN = true
+	d.routePoll = time.Millisecond
+	d.routeBudget = 200 * time.Millisecond
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
+
+	if err := d.RouteAddress(context.Background(), AddressSpec{
+		Machine: "srv", Address: "203.0.113.4", Network: "fnt-368798629f8",
+	}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if reads := f.matching("addr show dev eth0"); len(reads) > 1 {
+		t.Errorf("a link nobody manages was polled %d time(s) for an address no guest will lay (#742):\n%s",
+			len(reads), strings.Join(f.commands(), "\n"))
+	}
+	if step(f, "ip route add default via 169.254.0.1 dev eth0") < 0 {
+		t.Errorf("the routed interface was left without its default route through %s:\n%s",
+			routedNextHop, strings.Join(f.commands(), "\n"))
 	}
 }

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1401,7 +1401,11 @@ func (d *Incus) reconcileRoutedNICs(ctx context.Context, machine string, devices
 		if cfg["type"] != "nic" || cfg["nictype"] != "routed" || device != routedDeviceName {
 			continue
 		}
-		if err := d.reconcileRoutedInterface(ctx, machine, device, cfg); err != nil {
+		// A boot lays the interface on every image this emulator builds —
+		// netplan and networkd on Ubuntu, ifupdown on Debian and Alpine,
+		// NetworkManager on the RHEL family — so after a boot the guest is
+		// always waited for.
+		if err := d.reconcileRoutedInterface(ctx, machine, device, cfg, true); err != nil {
 			return err
 		}
 	}
@@ -1446,12 +1450,23 @@ func (d *Incus) reconcileRoutedNICs(ctx context.Context, machine string, devices
 // The wait is bounded and its expiry is reported after the reconciliation
 // rather than instead of it (waitForGuestInterface), as the restart path
 // always did. A stopped machine is the caller's question, asked before this
-// runs: there is no guest to wait for.
+// runs: there is no guest to wait for. And so is whether the guest has a
+// writer for the link at all (guestWrites): after a boot every image lays
+// its interfaces, but after a re-plug only a stack that reacts to a link
+// appearing does — systemd-networkd with a unit for it, measured — and an
+// ifupdown guest, an Alpine one, or an unmanaged link would be polled for
+// the whole budget for an address nobody is going to lay. That is #694's
+// shape, a transient case not told from a permanent one, and it would make
+// a hot address attach cost ninety seconds on half the images.
 //
 // TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff fails
-// without the wait, and without this order.
-func (d *Incus) reconcileRoutedInterface(ctx context.Context, machine, device string, cfg map[string]string) error {
-	waited := d.waitForGuestInterface(ctx, machine, device)
+// without the wait, and without this order;
+// TestAHotMigrationOnALinkNobodyManagesDoesNotWait without the other half.
+func (d *Incus) reconcileRoutedInterface(ctx context.Context, machine, device string, cfg map[string]string, guestWrites bool) error {
+	var waited error
+	if guestWrites {
+		waited = d.waitForGuestInterface(ctx, machine, device)
+	}
 	if err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {
 		return err
 	}

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1401,18 +1401,64 @@ func (d *Incus) reconcileRoutedNICs(ctx context.Context, machine string, devices
 		if cfg["type"] != "nic" || cfg["nictype"] != "routed" || device != routedDeviceName {
 			continue
 		}
-		waited := d.waitForGuestInterface(ctx, machine, device)
-		if err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {
+		if err := d.reconcileRoutedInterface(ctx, machine, device, cfg); err != nil {
 			return err
-		}
-		if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
-			return err
-		}
-		if waited != nil {
-			return waited
 		}
 	}
 	return nil
+}
+
+// reconcileRoutedInterface is the one order the two writers of a routed
+// interface are held to, after a boot and after a re-plug alike (#674, #742):
+// the guest's own config goes first, and the driver waits its turn.
+//
+// A re-plug is a boot as far as the guest's network stack is concerned. The
+// interface disappears and comes back, and systemd-networkd applies the
+// netplan cloud-init rendered at the first boot to the new link — the launch
+// address, the default route through the link-local next hop — exactly as it
+// does after `incus start`. Until #742 only the restart path waited for that
+// to have happened before writing; the migration of #548 repaired the
+// interface the moment the device edit returned and deleted the moved address
+// right after, so it raced networkd on the link it had just re-plugged, and
+// which of the two wrote last decided what the machine carried. Measured
+// 2026-09-07 on platform-web-0 of the Scaleway example stack, `--vm
+// incus-ovn`, the same reboot verb on two runs:
+//
+//	networkd first, then the driver's del:  eth0 bare, no default route
+//	the driver's del first, then networkd:  eth0 203.0.113.4/32 + default via 169.254.0.1
+//
+// while the boot, polled at half-second intervals, always came out the same:
+// netplan wrote eth0 0.5 s after the container was back, the driver took the
+// stale address off 2.2 s after, the driver laid the default route 2.8 s
+// after, and the machine held that for the 150 s it was watched. So the
+// reboot comparison of #671 reported a difference on every run, in one
+// direction or the other, and the reboot was never what differed.
+//
+// What this produces is deliberately unchanged: a routed interface carrying
+// exactly what its device pins and routes, plus the link-local next hop and
+// the default route through it, which for a migrated machine is an interface
+// with no address and a default route. That shape is discussable — a default
+// route through an addressless interface is what #647 met on the bastion —
+// and deciding it is #695's outbound half and the ADR of #726, not this
+// order. Here the shape is made the same by both doors, so the comparison
+// can judge a reboot rather than a race.
+//
+// The wait is bounded and its expiry is reported after the reconciliation
+// rather than instead of it (waitForGuestInterface), as the restart path
+// always did. A stopped machine is the caller's question, asked before this
+// runs: there is no guest to wait for.
+//
+// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff fails
+// without the wait, and without this order.
+func (d *Incus) reconcileRoutedInterface(ctx context.Context, machine, device string, cfg map[string]string) error {
+	waited := d.waitForGuestInterface(ctx, machine, device)
+	if err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {
+		return err
+	}
+	if err := d.repairRoutedInterface(ctx, machine, device); err != nil {
+		return err
+	}
+	return waited
 }
 
 // releaseStaleRoutedAddresses takes off the guest's routed interface every

--- a/internal/core/machine/incus_ovn.go
+++ b/internal/core/machine/incus_ovn.go
@@ -1401,70 +1401,83 @@ func (d *Incus) reconcileRoutedNICs(ctx context.Context, machine string, devices
 		if cfg["type"] != "nic" || cfg["nictype"] != "routed" || device != routedDeviceName {
 			continue
 		}
-		// A boot lays the interface on every image this emulator builds —
-		// netplan and networkd on Ubuntu, ifupdown on Debian and Alpine,
-		// NetworkManager on the RHEL family — so after a boot the guest is
-		// always waited for.
-		if err := d.reconcileRoutedInterface(ctx, machine, device, cfg, true); err != nil {
+		if err := d.reconcileRoutedInterface(ctx, machine, device, cfg); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// reconcileRoutedInterface is the one order the two writers of a routed
-// interface are held to, after a boot and after a re-plug alike (#674, #742):
-// the guest's own config goes first, and the driver waits its turn.
+// reconcileRoutedInterface makes the guest's routed interface carry what its
+// device carries, after a boot and after a re-plug alike (#674, #742), and it
+// is one sequence for both doors so they cannot diverge again.
 //
-// A re-plug is a boot as far as the guest's network stack is concerned. The
-// interface disappears and comes back, and systemd-networkd applies the
-// netplan cloud-init rendered at the first boot to the new link — the launch
-// address, the default route through the link-local next hop — exactly as it
-// does after `incus start`. Until #742 only the restart path waited for that
-// to have happened before writing; the migration of #548 repaired the
-// interface the moment the device edit returned and deleted the moved address
-// right after, so it raced networkd on the link it had just re-plugged, and
-// which of the two wrote last decided what the machine carried. Measured
-// 2026-09-07 on platform-web-0 of the Scaleway example stack, `--vm
-// incus-ovn`, the same reboot verb on two runs:
+// Two writers of one interface. The guest's own config (routedNetworkConfig,
+// rendered once by cloud-init at the first boot) lays eth0 with the launch
+// address and the default route through the link-local next hop; the driver
+// lays what the device pins and routes. Which of the two goes last decides
+// what the machine carries, and until #742 the answer differed by door and by
+// station: the restart path waited for the guest to lay the interface before
+// writing (#674), the hot migration of #548 wrote the moment its device edit
+// returned, and the reboot comparison of #671 reported the difference on
+// every run, on the runner as on the author's station, in one direction or
+// the other. Measured 2026-09-07 at 100 ms across a hot attach: the re-plugged
+// link answers `Network File: n/a` for 150 ms before networkd matches it and
+// lays the launch config, so an order that waits for the guest's write can
+// still ask in that window, read "nobody manages this", and write first.
+// While networkd owns the interface's configuration, every order is a race.
 //
-//	networkd first, then the driver's del:  eth0 bare, no default route
-//	the driver's del first, then networkd:  eth0 203.0.113.4/32 + default via 169.254.0.1
+// So the two cases are told apart by what the device carries, and neither
+// races:
 //
-// while the boot, polled at half-second intervals, always came out the same:
-// netplan wrote eth0 0.5 s after the container was back, the driver took the
-// stale address off 2.2 s after, the driver laid the default route 2.8 s
-// after, and the machine held that for the 150 s it was watched. So the
-// reboot comparison of #671 reported a difference on every run, in one
-// direction or the other, and the reboot was never what differed.
+//   - a device that still pins or routes an address is one whose guest config
+//     is right, and the driver waits for the guest to have laid the interface
+//     before it puts back what the device declares — when the guest has a
+//     writer for it at all, which an interface this driver took away from
+//     networkd no longer has;
+//   - a device that carries nothing is one whose address moved (#548), and
+//     whose guest config is stale: the driver tells networkd to let go of the
+//     interface in networkd's own configuration (unmanageGuestInterface), waits
+//     for networkd to report the STATE, not the effect, and only then takes
+//     the stale address off and lays the next hop and the default route. From
+//     then on nobody else writes it, at this re-plug or at any later boot.
 //
-// What this produces is deliberately unchanged: a routed interface carrying
-// exactly what its device pins and routes, plus the link-local next hop and
-// the default route through it, which for a migrated machine is an interface
-// with no address and a default route. That shape is discussable — a default
-// route through an addressless interface is what #647 met on the bastion —
-// and deciding it is #695's outbound half and the ADR of #726, not this
-// order. Here the shape is made the same by both doors, so the comparison
-// can judge a reboot rather than a race.
+// What is produced is deliberately unchanged: a routed interface carrying
+// exactly what its device pins and routes, plus the next hop and the default
+// route through it, which for a migrated machine is an interface with no
+// address and a default route. That shape is discussable — a default route
+// through an addressless interface is what #647 met on the bastion — and
+// deciding it is #695's outbound half and the ADR of #726. #742 changes who
+// writes it, not what is written, so the comparison can judge a reboot rather
+// than a race.
 //
-// The wait is bounded and its expiry is reported after the reconciliation
-// rather than instead of it (waitForGuestInterface), as the restart path
-// always did. A stopped machine is the caller's question, asked before this
-// runs: there is no guest to wait for. And so is whether the guest has a
-// writer for the link at all (guestWrites): after a boot every image lays
-// its interfaces, but after a re-plug only a stack that reacts to a link
-// appearing does — systemd-networkd with a unit for it, measured — and an
-// ifupdown guest, an Alpine one, or an unmanaged link would be polled for
-// the whole budget for an address nobody is going to lay. That is #694's
-// shape, a transient case not told from a permanent one, and it would make
-// a hot address attach cost ninety seconds on half the images.
+// The wait for the guest is bounded and its expiry reported after the
+// reconciliation rather than instead of it (waitForGuestInterface), as the
+// restart path always did. A stopped machine is the caller's question, asked
+// before this runs: there is no guest to write, and no guest to wait for.
 //
-// TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff fails
-// without the wait, and without this order;
-// TestAHotMigrationOnALinkNobodyManagesDoesNotWait without the other half.
-func (d *Incus) reconcileRoutedInterface(ctx context.Context, machine, device string, cfg map[string]string, guestWrites bool) error {
+// TestARestartTellsNetworkdToLetGoOfAMigratedRoutedNIC and
+// TestARebootOfAMigratedMachineDoesNotWaitForAnAddressNobodyLays fail without
+// the second case; TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug holds
+// the hot door in releaseFromRoutedNIC.
+func (d *Incus) reconcileRoutedInterface(ctx context.Context, machine, device string, cfg map[string]string) error {
 	var waited error
-	if guestWrites {
+	if routedDeviceCarriesNothing(cfg) {
+		if _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {
+			return err
+		}
+	} else if iface, err := d.guestInterface(ctx, machine, device); err != nil {
+		return err
+	} else if d.guestNetworkUnit(ctx, machine, iface) != "" {
+		// Waited for only when the guest has a writer for it. An interface
+		// this driver took away from networkd stays nobody's for the rest of
+		// the machine's life, and no path hands it back: an address routed
+		// onto it again later (routeOntoRoutedNIC, after the private NIC that
+		// carried the migrated address is detached) is laid by the driver
+		// itself, here and at every re-plug, which is one writer where there
+		// used to be two. A wait for the guest to lay such an interface would
+		// expire on every boot, #694's shape once more.
+		// TestARestartOfARoutedNICNobodyManagesDoesNotWait fails without this.
 		waited = d.waitForGuestInterface(ctx, machine, device)
 	}
 	if err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {

--- a/internal/core/machine/incus_routed_boot_test.go
+++ b/internal/core/machine/incus_routed_boot_test.go
@@ -136,35 +136,108 @@ func TestARestartKeepsTheAddressTheRoutedNICStillPins(t *testing.T) {
 	}
 }
 
-// TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling: the order is
-// the mechanism. The guest's config lays eth0 a moment after `incus start`
-// returns; a reconciliation that read the interface before that would find it
-// bare, take nothing off, and the stale address would land afterwards. The
-// guest here answers bare twice and then carries the migrated address; the
-// removal must come after that.
-func TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling(t *testing.T) {
+// TestARestartTellsNetworkdToLetGoOfAMigratedRoutedNIC: the boot door of
+// #742. A machine migrated while stopped boots with its netplan still
+// declaring the launch address on eth0, so networkd lays it; the restart path
+// finds a device that carries nothing, tells networkd in its own configuration
+// to let go (a drop-in beside the unit the guest names, a reload), reads
+// networkd's state until it reports the link unmanaged, and only then takes
+// the stale address off and lays the default route. The guest here answers
+// (configuring) twice after the reload before (unmanaged); the removal must
+// come after that, and it must come: written as a wait for the guest to LAY
+// the interface, the same boot read a bare link, took nothing off, and the
+// address landed afterwards.
+func TestARestartTellsNetworkdToLetGoOfAMigratedRoutedNIC(t *testing.T) {
 	f := &fakeRuntime{}
 	restartedInstanceCarrying(f, migratedRouted, "203.0.113.7")
 	inner := f.hook
-	reads := 0
+	reloaded := false
+	statusReads := 0
 	f.hook = func(n int, args []string) ([]byte, error, bool) {
-		if args[0] == "exec" && strings.Contains(strings.Join(args, " "), "-o addr show dev eth0") {
-			reads++
-			if reads <= 2 {
-				return []byte(""), nil, true
+		key := strings.Join(args, " ")
+		switch {
+		case strings.Contains(key, "networkctl reload"):
+			reloaded = true
+			return nil, nil, true
+		case strings.Contains(key, "networkctl status eth0"):
+			if !reloaded {
+				return []byte(managedByNetworkd), nil, true
 			}
+			statusReads++
+			if statusReads < statusReadsToSettle {
+				return []byte(stillConfiguring), nil, true
+			}
+			return []byte(letGoByNetworkd), nil, true
+		}
+		return inner(n, args)
+	}
+	d := ovnDriver(f)
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = time.Second
+
+	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
+		t.Fatalf("start an existing machine: %v", err)
+	}
+	dropIn := step(f, unmanagedDropIn)
+	del := step(f, "ip address del 203.0.113.7/32 dev eth0")
+	reload := -1
+	for i, cmd := range f.commands() {
+		if i > dropIn && strings.Contains(cmd, "networkctl reload") {
+			reload = i
+			break
+		}
+	}
+	switch {
+	case dropIn < 0:
+		t.Fatalf("the boot left eth0 to networkd, whose config still lays the migrated address (#742):\n%s",
+			strings.Join(f.commands(), "\n"))
+	case reload < 0:
+		t.Fatalf("the drop-in was written and networkd never told to read it:\n%s", strings.Join(f.commands(), "\n"))
+	case del < 0:
+		t.Fatalf("the migrated address was left on the routed NIC:\n%s", strings.Join(f.commands(), "\n"))
+	case statusReadsBetween(f, reload, del) < statusReadsToSettle:
+		t.Errorf("the address was taken off before networkd reported the link unmanaged (%d state read(s) "+
+			"after the reload), which is the order the address lands afterwards in:\n%s",
+			statusReadsBetween(f, reload, del), strings.Join(f.commands(), "\n"))
+	case step(f, "ip route add default via 169.254.0.1 dev eth0") < 0:
+		t.Errorf("the restart took the door away with the address:\n%s", strings.Join(f.commands(), "\n"))
+	}
+}
+
+// TestARebootOfAMigratedMachineDoesNotWaitForAnAddressNobodyLays: once the
+// drop-in is there, eth0 is nobody's from the first moment of every boot, the
+// guest names no unit for it, and a wait for an address that no one will lay
+// would cost every reboot of a migrated machine the whole budget — #694's
+// shape, reintroduced by #742's own fix. The interface is read once, for the
+// release, and the routes are laid.
+func TestARebootOfAMigratedMachineDoesNotWaitForAnAddressNobodyLays(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstanceCarrying(f, migratedRouted, "")
+	inner := f.hook
+	f.hook = func(n int, args []string) ([]byte, error, bool) {
+		if strings.Contains(strings.Join(args, " "), "networkctl status eth0") {
+			return []byte(letGoByNetworkd), nil, true
 		}
 		return inner(n, args)
 	}
 	d := ovnDriver(f)
 	d.routePoll = time.Millisecond
+	d.routeBudget = 200 * time.Millisecond
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
 
-	if _, err := d.Start(context.Background(), Spec{Name: "srv", Image: "ubuntu:22.04"}); err != nil {
-		t.Fatalf("start an existing machine: %v", err)
+	if err := d.restoreGuestNetwork(context.Background(), "srv"); err != nil {
+		t.Fatalf("a migrated machine whose routed NIC nobody lays was reported: %v", err)
 	}
-	if len(f.matching("exec srv -- ip address del 203.0.113.7/32 dev eth0")) == 0 {
-		t.Errorf("the reconciliation read the routed NIC before the guest had laid it, and took nothing off (%d reads):\n%s",
-			reads, strings.Join(f.commands(), "\n"))
+	if got := f.matching(unmanagedDropIn); len(got) != 0 {
+		t.Errorf("a drop-in was written for a link networkd already let go of:\n%s", strings.Join(got, "\n"))
+	}
+	if reads := f.matching("-o addr show dev eth0"); len(reads) > 1 {
+		t.Errorf("the routed NIC nobody lays was polled %d time(s) for an address (#742):\n%s",
+			len(reads), strings.Join(f.commands(), "\n"))
+	}
+	if len(f.matching("exec srv -- ip route add default via 169.254.0.1 dev eth0")) == 0 {
+		t.Errorf("the restart took the door away:\n%s", strings.Join(f.commands(), "\n"))
 	}
 }
 
@@ -175,6 +248,16 @@ func TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling(t *testing.T
 func TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC(t *testing.T) {
 	f := &fakeRuntime{}
 	restartedInstanceCarrying(f, launchRouted, "")
+	// The guest manages the interface and never lays it, which is the case
+	// the wait is for; an interface nobody manages is not waited for at all
+	// (the test below).
+	inner := f.hook
+	f.hook = func(n int, args []string) ([]byte, error, bool) {
+		if strings.Contains(strings.Join(args, " "), "networkctl status eth0") {
+			return []byte(managedByNetworkd), nil, true
+		}
+		return inner(n, args)
+	}
 	d := ovnDriver(f)
 	d.routePoll = time.Millisecond
 	d.routeBudget = 5 * time.Millisecond
@@ -194,6 +277,39 @@ func TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC(t *testing.T) 
 	}
 	if got := f.matching("ip address del"); len(got) != 0 {
 		t.Errorf("nothing was carried and something was taken off:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// TestARestartOfARoutedNICNobodyManagesDoesNotWait: an interface this driver
+// took away from networkd (#742) that an address was later routed back onto
+// has no writer in the guest, and the boot must not wait for one: the driver
+// lays what the device declares, at once, and the boot goes on.
+func TestARestartOfARoutedNICNobodyManagesDoesNotWait(t *testing.T) {
+	f := &fakeRuntime{}
+	restartedInstanceCarrying(f, launchRouted, "")
+	inner := f.hook
+	f.hook = func(n int, args []string) ([]byte, error, bool) {
+		if strings.Contains(strings.Join(args, " "), "networkctl status eth0") {
+			return []byte(letGoByNetworkd), nil, true
+		}
+		return inner(n, args)
+	}
+	d := ovnDriver(f)
+	d.routePoll = time.Millisecond
+	d.routeBudget = 200 * time.Millisecond
+	d.resolverPoll = time.Millisecond
+	d.resolverWait = 20 * time.Millisecond
+
+	if err := d.restoreGuestNetwork(context.Background(), "srv"); err != nil {
+		t.Fatalf("a routed NIC nobody manages was waited for and reported: %v", err)
+	}
+	if reads := f.matching("-o addr show dev eth0"); len(reads) > 1 {
+		t.Errorf("the routed NIC nobody manages was polled %d time(s) for an address no guest will lay (#742):\n%s",
+			len(reads), strings.Join(f.commands(), "\n"))
+	}
+	if len(f.matching("exec srv -- ip address add 203.0.113.7/32 dev eth0")) == 0 {
+		t.Errorf("the boot left the routed NIC bare instead of laying the device on it:\n%s",
+			strings.Join(f.commands(), "\n"))
 	}
 }
 

--- a/internal/core/machine/incus_unmanaged.go
+++ b/internal/core/machine/incus_unmanaged.go
@@ -1,0 +1,130 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// A routed interface whose address has moved (#548) is one the guest's own
+// network stack must stop writing (#742).
+//
+// The guest's netplan, rendered once by cloud-init at the first boot
+// (routedNetworkConfig), declares eth0 with the launch address and the default
+// route through the link-local next hop, and systemd-networkd re-applies it
+// every time the link appears: at a boot, and at the re-plug an ipv4.address
+// edit causes. Once the address has moved onto the filtered NIC, that config
+// is stale, and every order the driver takes against it is a race: measured
+// on 2026-09-07 at 100 ms across a hot attach, the re-plugged link answers
+// `Network File: n/a, State: off (unmanaged)` for 150 ms before networkd
+// matches it and lays the launch address, and the driver's `ip address del`
+// wins only when it lands after that write. On the author's station it did;
+// on the runner it did not (run 34124737760), and the reboot comparison of
+// #671 reported the difference. Whether the runner's shape came from that
+// window or from a second, reload-triggered write cannot be told from its log,
+// and it does not matter: while networkd owns eth0's configuration, the
+// driver deleting what networkd lays wins sometimes, and "sometimes" is what
+// the comparison measures. #696 wrote the lesson for the resolver — a value
+// networkd owns cannot be held outside networkd's configuration — and this is
+// the same lesson for the address.
+//
+// So the driver tells networkd, in networkd's own configuration, to let go:
+// a drop-in beside the unit netplan rendered for the interface, which #702
+// already writes for the resolver at the same path, carrying
+// `[Link] Unmanaged=yes`; a reload; and then a wait for the STATE networkd
+// reports for the link, `(unmanaged)`, rather than for any effect. From then
+// on nobody but the driver writes eth0, at the re-plug and at every boot after
+// it, since netplan regenerates the unit under /run and the drop-in under /etc
+// applies to it (#702 measured that across a container restart).
+//
+// What this changes is who writes the interface, not what is written: the
+// shape stays an addressless routed interface carrying the next hop and the
+// default route through it (repairRoutedInterface), which is the shape this
+// driver produced after a boot before #742, discussable, and decided by
+// #695's outbound half and the ADR of #726 rather than here. A guest with no
+// networkd (Alpine, an ifupdown Debian) has no unit to name and nothing to
+// let go of, and is left alone.
+
+// unmanagedDropIn is the file's name beside the resolver's feint-dns.conf.
+const unmanagedDropIn = "feint-unmanaged.conf"
+
+// unmanageGuestInterface takes an interface away from systemd-networkd, and
+// reports whether networkd had it. Nothing is asked of a guest that names no
+// unit for the interface: no networkd, or a link nobody manages.
+func (d *Incus) unmanageGuestInterface(ctx context.Context, machine, device string) (bool, error) {
+	iface, err := d.guestInterface(ctx, machine, device)
+	if err != nil {
+		return false, err
+	}
+	unit := d.guestNetworkUnit(ctx, machine, iface)
+	if unit == "" {
+		return false, nil
+	}
+	dropIn := "/etc/systemd/network/" + unit + ".d/" + unmanagedDropIn
+	script := "mkdir -p " + shellQuote(dropIn[:strings.LastIndex(dropIn, "/")]) +
+		" && printf '[Link]\\nUnmanaged=yes\\n' > " + shellQuote(dropIn)
+	if _, err := d.run(ctx, "exec", machine, "--", "sh", "-c", script); err != nil {
+		if isNotRunning(err) || isNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("tell the guest's network stack to let go of %s/%s: %w", machine, iface, err)
+	}
+	if err := d.reloadGuestNetwork(ctx, machine); err != nil {
+		return false, fmt.Errorf("the guest was not told to read that %s/%s is nobody's: %w", machine, iface, err)
+	}
+	if err := d.waitForGuestLinkUnmanaged(ctx, machine, iface); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// waitForGuestLinkUnmanaged blocks until networkd reports the link as one it
+// does not manage. A state the driver itself provoked, so the wait is short in
+// the ordinary case and bounded in every other; an image without networkctl
+// answers once and is not waited for.
+func (d *Incus) waitForGuestLinkUnmanaged(ctx context.Context, machine, iface string) error {
+	deadline := time.Now().Add(d.resolverBudget())
+	for {
+		state, err := d.readGuestLinkState(ctx, machine, iface)
+		if err == nil && strings.Contains(state, "(unmanaged)") {
+			return nil
+		}
+		if err != nil && (isNotRunning(err) || guestHasNoNetworkd(err)) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if err == nil {
+				err = fmt.Errorf("networkd still reports %q", state)
+			}
+			return fmt.Errorf("wait for the guest's network stack to let go of %s/%s: %w", machine, iface, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(d.resolverInterval()):
+		}
+	}
+}
+
+// readGuestLinkState is the `State:` line of `networkctl status <iface>`,
+// which carries networkd's own setup state for the link in parentheses:
+// (pending), (configuring), (configured), (unmanaged).
+func (d *Incus) readGuestLinkState(ctx context.Context, machine, iface string) (string, error) {
+	out, err := d.run(ctx, "exec", machine, "--", "networkctl", "status", iface)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if _, after, found := strings.Cut(line, "State:"); found {
+			return strings.TrimSpace(after), nil
+		}
+	}
+	return "", nil
+}
+
+// routedDeviceCarriesNothing: a routed device that pins no address and routes
+// none is one whose address moved (#548), or that never had one.
+func routedDeviceCarriesNothing(cfg map[string]string) bool {
+	return len(splitList(cfg["ipv4.address"])) == 0 && len(splitList(cfg["ipv4.routes"])) == 0
+}

--- a/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
+++ b/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
@@ -32,8 +32,8 @@
     {
       "label": "the reconciliation does not wait for the guest to lay the interface, reads it bare, and takes nothing off (#674)",
       "file": "internal/core/machine/incus_ovn.go",
-      "find": "\twaited := d.waitForGuestInterface(ctx, machine, device)",
-      "replace": "\twaited := func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
+      "find": "\t\twaited = d.waitForGuestInterface(ctx, machine, device)",
+      "replace": "\t\twaited = func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
       "test": "TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling"
     },
     {

--- a/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
+++ b/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
@@ -30,11 +30,11 @@
       "test": "TestARestartReconcilesTheRoutedNICToItsDevice"
     },
     {
-      "label": "the reconciliation does not wait for the guest to lay the interface, reads it bare, and takes nothing off (#674)",
+      "label": "the reconciliation does not wait for the guest to lay an interface the device still pins, reads it bare, and the expired wait is never reported (#674)",
       "file": "internal/core/machine/incus_ovn.go",
       "find": "\t\twaited = d.waitForGuestInterface(ctx, machine, device)",
       "replace": "\t\twaited = func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
-      "test": "TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling"
+      "test": "TestARestartStillReconcilesWhenTheGuestNeverLaysItsRoutedNIC"
     },
     {
       "label": "the restart reconciles every routed NIC, an operator's included (#674)",
@@ -42,6 +42,14 @@
       "find": "\t\tif cfg[\"type\"] != \"nic\" || cfg[\"nictype\"] != \"routed\" || device != routedDeviceName {\n\t\t\tcontinue\n\t\t}",
       "replace": "\t\tif cfg[\"type\"] != \"nic\" || cfg[\"nictype\"] != \"routed\" || (device != routedDeviceName && false) {\n\t\t\tcontinue\n\t\t}",
       "test": "TestARestartLeavesAForeignRoutedNICAlone"
+    },
+    {
+      "label": "a routed NIC nobody manages is waited for at boot, so every boot of a machine whose address was routed back onto the interface the driver owns burns the whole budget (#742)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t} else if d.guestNetworkUnit(ctx, machine, iface) != \"\" {",
+      "replace": "\t} else if d.guestNetworkUnit(ctx, machine, iface) != \"\\x00never\" {",
+      "test": "TestARestartOfARoutedNICNobodyManagesDoesNotWait"
     }
   ]
 }

--- a/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
+++ b/tools/falsify/specs/a-restart-reconciles-the-routed-nic.json
@@ -32,8 +32,8 @@
     {
       "label": "the reconciliation does not wait for the guest to lay the interface, reads it bare, and takes nothing off (#674)",
       "file": "internal/core/machine/incus_ovn.go",
-      "find": "\t\twaited := d.waitForGuestInterface(ctx, machine, device)",
-      "replace": "\t\twaited := func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
+      "find": "\twaited := d.waitForGuestInterface(ctx, machine, device)",
+      "replace": "\twaited := func() error { _ = d.waitForGuestInterface; _, _, _ = ctx, machine, device; return nil }()",
       "test": "TestARestartWaitsForTheGuestToLayItsRoutedNICBeforeReconciling"
     },
     {

--- a/tools/falsify/specs/public-address-migration.json
+++ b/tools/falsify/specs/public-address-migration.json
@@ -27,6 +27,22 @@
       "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
     },
     {
+      "label": "a link nobody manages is waited for anyway, so a hot address attach on an image without networkd costs the whole budget for an address no guest will lay (#742)",
+      "file": "internal/core/machine/incus_address.go",
+      "package": "./internal/core/machine/",
+      "find": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\"",
+      "replace": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\\x00never\"",
+      "test": "TestAHotMigrationOnALinkNobodyManagesDoesNotWait"
+    },
+    {
+      "label": "the hot migration stops waiting whatever the guest says about the link's writer, so the driver's writes race networkd's again (#742)",
+      "file": "internal/core/machine/incus_address.go",
+      "package": "./internal/core/machine/",
+      "find": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\"",
+      "replace": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) == \"\\x00never\"",
+      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
+    },
+    {
       "label": "a cold migration is reconciled like a hot one, polling a stopped machine for an interface no guest will lay (#742)",
       "file": "internal/core/machine/incus_address.go",
       "package": "./internal/core/machine/",

--- a/tools/falsify/specs/public-address-migration.json
+++ b/tools/falsify/specs/public-address-migration.json
@@ -11,6 +11,30 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
+      "label": "the hot migration stops waiting for the guest's own config to lay the re-plugged interface, so the driver's writes race networkd's and what the machine carries before a reboot depends on who wrote last (#742)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\t\tif err == nil && len(carried) > 0 {\n\t\t\t\treturn nil\n\t\t\t}",
+      "replace": "\t\t\tif err == nil && len(carried) >= 0 {\n\t\t\t\treturn nil\n\t\t\t}",
+      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
+    },
+    {
+      "label": "the repair goes back before the release, so the default route the driver lays is the one the address deletion takes away (#742)",
+      "file": "internal/core/machine/incus_ovn.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {\n\t\treturn err\n\t}\n\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\treturn err\n\t}\n\treturn waited",
+      "replace": "\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\treturn err\n\t}\n\tif err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {\n\t\treturn err\n\t}\n\treturn waited",
+      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
+    },
+    {
+      "label": "a cold migration is reconciled like a hot one, polling a stopped machine for an interface no guest will lay (#742)",
+      "file": "internal/core/machine/incus_address.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif !found || !m.Running {\n\t\treturn nil\n\t}",
+      "replace": "\tif !found || (!m.Running && false) {\n\t\treturn nil\n\t}",
+      "test": "TestAColdMigrationDoesNotWaitForTheGuest"
+    },
+    {
       "label": "the migration reconfigures an instance without asking whether the emulator created it",
       "file": "internal/core/machine/incus_address.go",
       "find": "func (d *Incus) releaseFromRoutedNIC(ctx context.Context, machine, device, address string) error {\n\tif err := d.mustOwnInstance(ctx, machine); err != nil {\n\t\treturn err\n\t}",

--- a/tools/falsify/specs/public-address-migration.json
+++ b/tools/falsify/specs/public-address-migration.json
@@ -11,44 +11,52 @@
   "package": "./internal/core/machine/",
   "mutations": [
     {
-      "label": "the hot migration stops waiting for the guest's own config to lay the re-plugged interface, so the driver's writes race networkd's and what the machine carries before a reboot depends on who wrote last (#742)",
+      "label": "networkd is not told to let go of eth0 before the re-plug, so the new link is matched and written in the window where the driver reads n/a and writes first (#742)",
+      "file": "internal/core/machine/incus_address.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif running && routedDeviceCarriesNothing(after) {\n\t\tif _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {",
+      "replace": "\tif running && routedDeviceCarriesNothing(after) && false {\n\t\tif _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {",
+      "test": "TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug"
+    },
+    {
+      "label": "the drop-in is written and networkd never told to read it, so the file is one nobody has looked at and networkd goes on writing eth0 (#742)",
+      "file": "internal/core/machine/incus_unmanaged.go",
+      "package": "./internal/core/machine/",
+      "find": "\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {\n\t\treturn false, fmt.Errorf(\"the guest was not told to read that %s/%s is nobody's: %w\", machine, iface, err)\n\t}",
+      "replace": "\tif false {\n\t\tif err := d.reloadGuestNetwork(ctx, machine); err != nil {\n\t\t\treturn false, fmt.Errorf(\"the guest was not told to read that %s/%s is nobody's: %w\", machine, iface, err)\n\t\t}\n\t}",
+      "test": "TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug"
+    },
+    {
+      "label": "the driver goes on before networkd reports the link unmanaged: an effect is waited for instead of the state the driver provoked (#742)",
+      "file": "internal/core/machine/incus_unmanaged.go",
+      "package": "./internal/core/machine/",
+      "find": "\t\tif err == nil && strings.Contains(state, \"(unmanaged)\") {\n\t\t\treturn nil\n\t\t}",
+      "replace": "\t\tif err == nil && (strings.Contains(state, \"(unmanaged)\") || true) {\n\t\t\treturn nil\n\t\t}",
+      "test": "TestAHotMigrationTellsNetworkdToLetGoBeforeTheRePlug"
+    },
+    {
+      "label": "the boot after a cold migration does not tell networkd to let go, and the stale launch config keeps laying the migrated address at every boot (#742)",
       "file": "internal/core/machine/incus_ovn.go",
       "package": "./internal/core/machine/",
-      "find": "\t\t\tif err == nil && len(carried) > 0 {\n\t\t\t\treturn nil\n\t\t\t}",
-      "replace": "\t\t\tif err == nil && len(carried) >= 0 {\n\t\t\t\treturn nil\n\t\t\t}",
-      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
+      "find": "\tif routedDeviceCarriesNothing(cfg) {\n\t\tif _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {",
+      "replace": "\tif routedDeviceCarriesNothing(cfg) && false {\n\t\tif _, err := d.unmanageGuestInterface(ctx, machine, device); err != nil {",
+      "test": "TestARestartTellsNetworkdToLetGoOfAMigratedRoutedNIC"
     },
     {
-      "label": "the repair goes back before the release, so the default route the driver lays is the one the address deletion takes away (#742)",
-      "file": "internal/core/machine/incus_ovn.go",
-      "package": "./internal/core/machine/",
-      "find": "\tif err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {\n\t\treturn err\n\t}\n\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\treturn err\n\t}\n\treturn waited",
-      "replace": "\tif err := d.repairRoutedInterface(ctx, machine, device); err != nil {\n\t\treturn err\n\t}\n\tif err := d.releaseStaleRoutedAddresses(ctx, machine, device, cfg); err != nil {\n\t\treturn err\n\t}\n\treturn waited",
-      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
-    },
-    {
-      "label": "a link nobody manages is waited for anyway, so a hot address attach on an image without networkd costs the whole budget for an address no guest will lay (#742)",
+      "label": "a cold migration is reconciled like a hot one, reading and writing the routed interface of a stopped machine (#742)",
       "file": "internal/core/machine/incus_address.go",
       "package": "./internal/core/machine/",
-      "find": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\"",
-      "replace": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\\x00never\"",
-      "test": "TestAHotMigrationOnALinkNobodyManagesDoesNotWait"
-    },
-    {
-      "label": "the hot migration stops waiting whatever the guest says about the link's writer, so the driver's writes race networkd's again (#742)",
-      "file": "internal/core/machine/incus_address.go",
-      "package": "./internal/core/machine/",
-      "find": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) != \"\"",
-      "replace": "\tguestWrites := d.guestNetworkUnit(ctx, machine, iface) == \"\\x00never\"",
-      "test": "TestAHotMigrationWaitsForTheGuestBeforeTakingTheStaleAddressOff"
-    },
-    {
-      "label": "a cold migration is reconciled like a hot one, polling a stopped machine for an interface no guest will lay (#742)",
-      "file": "internal/core/machine/incus_address.go",
-      "package": "./internal/core/machine/",
-      "find": "\tif !found || !m.Running {\n\t\treturn nil\n\t}",
-      "replace": "\tif !found || (!m.Running && false) {\n\t\treturn nil\n\t}",
+      "find": "\tif !running {\n\t\treturn nil\n\t}\n\treturn d.reconcileRoutedInterface(ctx, machine, device, after)",
+      "replace": "\tif !running && false {\n\t\treturn nil\n\t}\n\treturn d.reconcileRoutedInterface(ctx, machine, device, after)",
       "test": "TestAColdMigrationDoesNotWaitForTheGuest"
+    },
+    {
+      "label": "a guest with no networkd is written a drop-in beside a unit it does not have, and the shell inside it builds a directory from an empty name (#742)",
+      "file": "internal/core/machine/incus_unmanaged.go",
+      "package": "./internal/core/machine/",
+      "find": "\tunit := d.guestNetworkUnit(ctx, machine, iface)\n\tif unit == \"\" {\n\t\treturn false, nil\n\t}",
+      "replace": "\tunit := d.guestNetworkUnit(ctx, machine, iface)\n\tif unit == \"\\x00never\" {\n\t\treturn false, nil\n\t}",
+      "test": "TestAGuestWithoutNetworkdIsLeftAloneByTheMigration"
     },
     {
       "label": "the migration reconfigures an instance without asking whether the emulator created it",


### PR DESCRIPTION
# Summary

The stack gate reds at the reboot comparison of #671 on `platform-web-0`, on
the runner as on the author's station, and the shape it reports differs from
one run to the next: once `before: addr eth0 203.0.113.4/32`, once `after:
route 0.0.0.0/0 via 169.254.0.1 dev eth0`. Four readings, four shapes, one
verb (#742).

**Measured, not deduced.** A half-second poll across the reboot: the reboot
itself is deterministic. netplan lays `eth0` (launch address, default via
`169.254.0.1`) 0.5 s after the container is back; the driver takes the stale
address off 2.2 s after; the driver lays the default route 2.8 s after; the
machine holds that for 150 s. What varies is the state **before** it. The
migration of #548 edits the routed device (a re-plug), repaired the interface
at once and deleted the moved address right after, while systemd-networkd
re-applies the guest's netplan to the new link. Networkd first, then the
driver's del: `eth0` bare, no default route. The driver's del first, then
networkd: `eth0` keeps the address and the default. The reboot converges both
to one shape, and the comparison reports the difference every time.

**The fix is an order, the one #674 already states** ("the driver goes
second, and waits its turn"), applied to the second path that needed it:

- `reconcileRoutedInterface` is the one sequence both paths go through: wait
  for the guest to have laid the interface, take off every address the device
  no longer pins or routes, put back what it does. `reconcileRoutedNICs`
  (restart) and `releaseFromRoutedNIC` (hot migration) both call it.
- A stopped machine is asked about before the guest work (`Inspect`): the
  cold Terraform order sets the device key and the next boot reconciles.
- The wait runs only when the guest has a writer for the re-plugged link,
  asked once through `guestNetworkUnit` (#696, hardened by #704): networkd
  with a unit, yes; no `networkctl` (Alpine), an unmanaged link (ifupdown),
  no. Without that half a hot address attach would have cost ninety seconds
  on half the images this emulator builds, #694's shape.

**What this deliberately does not decide**: the shape itself. Both paths now
produce an addressless routed interface carrying the default route through
`169.254.0.1`. Whether that is the right shape is #695's outbound half and the
ADR of #726, and the comment says so, so the question is not closed by
accident.

**Age of the defect**: older than v0.12.1. Today's gate driving a binary built
from that tag reaches the step and fails it too, by more (a second default
route via the private gateway, the DHCP-announced one #647 later silenced,
which is also the witness the binary under test was the old one). The
comparison that finds it is later than that tag, so no earlier release was
measured on this step, and the control leg `stacks (incus-ovn, last release)`
cannot bound it. Not measured: NetworkManager images (RHEL family), which
have no `networkctl` and therefore keep the pre-#742 race, status quo.

## Type of change

- [ ] A route added or changed
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Security / supply chain

## Checklist

### Always

- [x] `mise run check` passes (gofmt, vet, golangci-lint, `go test -race`)
- [x] No new external Go dependency, or the pull request justifies it
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider:
      the change is in the shared driver, for all three packs at once
- [x] `mise run testplan` was run, and what it printed was run — or this pull
      request names the run it skipped and why. Run: `mise run check`;
      `mise run falsify -- tools/falsify/specs/public-address-migration.json`
      (14 mutations, 5 new, all compile, all bite);
      `mise run falsify -- tools/falsify/specs/a-restart-reconciles-the-routed-nic.json`
      (6, one retargeted at the shared helper, all bite); `mise run falsify:lint`;
      `FEINT_VM=incus-ovn FEINT_FUNCTIONAL_PASSES=1 mise run conformance:functional`
      — **green end to end, both stacks, 383 s**, including `platform-web-0
      carries after the reboot verb exactly what it carried before the
      restart` and the same after a stop and a start, the two lines red since
      09-04; `FEINT_VM=incus-ovn mise run conformance:leg -- runtime`:
      RUNTIME_LEG_RESULT. Skipped: the full `mise run conformance`, the change
      is in the machine layer and no client suite of the matrix starts a
      runtime. `workflow_dispatch` of `runtime-proof.yml` on this branch:
      DISPATCH_RESULT.

### When a model wrote a substantive part of this — otherwise N/A

- [x] An `Assisted-by:` trailer names the tool and the model version
- [x] I ran `mise run conformance` myself — not "it should pass": the stack
      gate and the runtime leg, the runs this change reaches; see above
- [x] Every field name in the diff comes from the provider's SDK, their OpenAPI
      document, or a run of the real client, and I can say which: no API
      field; the device keys are Incus's (`ipv4.address`, `ipv4.routes`,
      `ipv4.host_address`) and the guest reads are `ip` and `networkctl`

### When a route is added or changed — otherwise N/A

N/A

### When behaviour a client can observe changes — otherwise N/A

- [x] `docs/limits.md` updated if the change moves a documented limit: no
      documented limit moves; the changelog entry names the shape and #695
- [x] The README's generated tables regenerated (`mise run docs:coverage`):
      `feint docs --check` answers 0, nothing generated moved

### When `.github/workflows/` is touched — otherwise N/A

N/A

### When a machine runtime is involved — otherwise N/A

- [x] Tested with `FEINT_VM=incus` (or `incus-vm`), not only with `--vm off`:
      `incus-ovn`, the mode the gate runs in and the defect was measured in;
      the bridge mode's routed path goes through the same helper
- [x] Nothing the emulator did not create was touched
- [x] The run leaves nothing behind — checked, not assumed: `incus list` and
      `incus network list` after the measurement run, the stack gate and the
      runtime leg: no `feint`/`fnt-` machine or network

## Related issues

Closes #742. Refs #548, #671, #674, #694, #695, #726, #736.
