### PR TITLE
fix(scaleway): an action that settled where it started narrates no chain, so a failed poweron stops claiming `starting` (#738)

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -418,6 +418,30 @@ change ni l'un ni l'autre a sa place dans `git log`.
 
 ### Corrigé
 
+- **Un poweron qui a échoué ne raconte plus `starting`** (#738). Sous
+  `--consistency eventual`, un démarrage dont l'appel au runtime avait échoué
+  répondait `[starting stopped stopped stopped]` sur quatre lectures, avec une
+  tâche annonçant `success` : un client qui suivait l'action voyait un
+  démarrage qui n'avait jamais eu lieu. `transitionTo` refusait toute valeur
+  d'arrivée hors de `running`, `stopped` et `stopped in place`, et l'état
+  d'échec de ce pack **est** `stopped`, Scaleway ne déclarant aucun état
+  d'erreur pour un serveur : la garde la laissait donc passer. Une action qui
+  arrive là où elle est partie n'a fait aucun trajet et n'en raconte plus ; un
+  redémarrage, qui revient légitimement à son point de départ, le dit par
+  `transitionBackTo` et garde sa chaîne. Cela rend vraie la phrase que
+  l'entrée de #637 ci-dessus affirmait déjà.
+
+  Le test est la partie qui mérite d'être lue. `TestAFailedActionWalksNoChain`
+  listait les états d'échec `failed`, `starting`, `unknown` et `""`, dont
+  aucun n'est produit par cette couche, tandis que sa moitié acceptante
+  exigeait une chaîne pour `from == settled == "stopped"`, c'est-à-dire le
+  poweron échoué lui-même. Il affirmait le défaut d'un côté et le manquait de
+  l'autre, sur une population qui excluait la seule valeur qui se produit. La
+  moitié acceptante nomme désormais des trajets (`stopped→running`,
+  `running→stopped`) plutôt que des destinations depuis une origine unique, et
+  `TestAFailedPoweronWalksNoChain` parcourt tout le chemin par HTTP, parce que
+  la garde unitaire était déjà réputée tenir.
+
 - **Une machine dont l'adresse publique a migré sur sa NIC privée porte la
   même forme avant et après le verbe de reboot : la migration à chaud attend
   que l'invité ait posé l'interface routée avant d'écrire, comme le chemin de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,28 @@ what this project is judged on: **a response shape a client can observe**, and
 
 ### Fixed
 
+- **A poweron that failed no longer narrates `starting`** (#738). Under
+  `--consistency eventual`, a start whose runtime call failed answered
+  `[starting stopped stopped stopped]` across four reads, with a task saying
+  `success`: a client watching the action saw a boot that never happened.
+  `transitionTo` refused any settled value outside `running`, `stopped` and
+  `stopped in place`, and this pack's failed state **is** `stopped` — Scaleway
+  declares no error state for a server — so the guard passed it. An action that
+  settles where it started made no journey and now narrates none; a reboot,
+  which legitimately returns to where it began, says so through
+  `transitionBackTo` and keeps its chain. This makes true the sentence #637's
+  entry above already claims.
+
+  The test is the part worth reading. `TestAFailedActionWalksNoChain` listed
+  the failed states `failed`, `starting`, `unknown` and `""`, none of which
+  this layer produces, while its accepting half required a chain for
+  `from == settled == "stopped"` — the failed poweron itself. It asserted the
+  defect in one half and missed it in the other, over a population that
+  excluded the only value that occurs. The accepting half now names journeys
+  (`stopped→running`, `running→stopped`) rather than destinations against one
+  origin, and `TestAFailedPoweronWalksNoChain` drives the whole path through
+  HTTP, because the unit-level guard was already believed to hold.
+
 - **A machine whose public address moved onto its private NIC carries the
   same shape before and after the reboot verb: the hot migration waits for
   the guest to lay the routed interface before it writes, as the restart path

--- a/internal/providers/scaleway/failedstart_test.go
+++ b/internal/providers/scaleway/failedstart_test.go
@@ -1,0 +1,85 @@
+package scaleway_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/feint/internal/core/emulator"
+	"github.com/stephrobert/feint/internal/core/machine"
+	"github.com/stephrobert/feint/internal/core/store"
+	"github.com/stephrobert/feint/internal/providers/scaleway"
+)
+
+// failingStartRuntime is the ordinary fake with one refusal: a launch that
+// cannot happen. An image the host does not hold is the everyday shape of it.
+type failingStartRuntime struct{ *fakeRuntime }
+
+func (r *failingStartRuntime) Start(context.Context, machine.Spec) (machine.Machine, error) {
+	return machine.Machine{}, errors.New("incus launch: image not found")
+}
+
+// TestAFailedPoweronWalksNoChain drives the whole path, through HTTP, on an
+// eventual store: a poweron whose Start fails must never narrate `starting`.
+//
+// The defect this holds (#738) is the one CLAUDE.md names for this layer —
+// "l'état publié est celui que l'effet a produit, pas celui que l'intention
+// visait" — one step earlier in the chain than the `running` that rule is
+// usually quoted about. Measured before the fix, four reads after the action:
+//
+//	[starting stopped stopped stopped]
+//
+// so a client watching the action saw a boot that never happened, and the task
+// it answered said `success`.
+//
+// It is driven through the API rather than against transitionTo because the
+// unit-level guard was already believed to hold: TestAFailedActionWalksNoChain
+// listed four failed states, none of which this pack produces, while its
+// accepting half required a chain for the one it does (`stopped`, the
+// FailedState of machines.go). A test whose population excludes the only value
+// that occurs proves nothing, and only the whole path shows it.
+func TestAFailedPoweronWalksNoChain(t *testing.T) {
+	rt := &failingStartRuntime{fakeRuntime: newFakeRuntime()}
+	// Nothing is held back: the refusal is the subject, not a race.
+	close(rt.release)
+
+	var seq atomic.Int64
+	st := store.New()
+	st.Eventual(true)
+	env := &emulator.Env{
+		Store: st,
+		Now:   func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		NewID: func() string {
+			return fmt.Sprintf("00000000-0000-4000-8000-%012d", seq.Add(1))
+		},
+	}
+	env.UseMachines(machine.Use(rt))
+	srv, err := emulator.NewServer(env, scaleway.New(env))
+	if err != nil {
+		t.Fatalf("build emulator: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	id, _ := serverWith(t, ts, `{"name":"failer","commercial_type":"DEV1-S"}`)
+	if code, _ := do(t, ts, "POST", zoneURL+"/servers/"+id+"/action", `{"action":"poweron"}`); code != 202 {
+		t.Fatalf("poweron answered %d", code)
+	}
+
+	// Four reads, because the chain is consumed one state per observation: a
+	// single read would pass over a chain of two.
+	for i := 1; i <= 4; i++ {
+		_, body := do(t, ts, "GET", zoneURL+"/servers/"+id, "")
+		server, _ := body["server"].(map[string]any)
+		state, _ := server["state"].(string)
+		if state != "stopped" {
+			t.Fatalf("read %d answered %q for a start that failed; the machine never left stopped, "+
+				"and narrating a path towards a boot that did not happen is the plausible-wrong "+
+				"answer this project exists to avoid (#738)", i, state)
+		}
+	}
+}

--- a/internal/providers/scaleway/servers.go
+++ b/internal/providers/scaleway/servers.go
@@ -1979,11 +1979,32 @@ func (p *Pack) nextVolumeKey(res *resource.Resource) string {
 // TestOnlyAChainThatSettlesWhereItStartedIsTheOnlySignal and
 // TestARebootIsObservableWithoutEventualConsistency fail without this.
 func transitionBackTo(res *resource.Resource, from, settled string, through ...string) {
-	transitionTo(res, from, settled, through...)
+	// Deliberately NOT through transitionTo: settling where it started is the
+	// whole point here, and transitionTo refuses exactly that (#738).
+	narrateChain(res, settled, through...)
 	res.PendingOnlySignal = len(res.Pending) > 0 && from == settled
 }
 
 func transitionTo(res *resource.Resource, from, settled string, through ...string) {
+	if settled == from {
+		// The action settled where it started, so nothing moved and there is no
+		// journey to narrate. This is what a FAILED action looks like here, and
+		// it is invisible to the check below: this pack's FailedState is
+		// `stopped` (machines.go, "Scaleway declares no error state for a
+		// server either"), an allowed value. Measured on 2026-09-07: a poweron
+		// whose Start fails answered [starting stopped stopped stopped] with a
+		// task saying `success` (#738).
+		//
+		// A reboot also settles where it started, and it says so through
+		// transitionBackTo rather than through this door.
+		return
+	}
+	narrateChain(res, settled, through...)
+}
+
+// narrateChain pushes the states a client watching an action would see, and is
+// the half both doors share.
+func narrateChain(res *resource.Resource, settled string, through ...string) {
 	if len(through) == 0 {
 		return
 	}

--- a/internal/providers/scaleway/transient_internal_test.go
+++ b/internal/providers/scaleway/transient_internal_test.go
@@ -22,20 +22,35 @@ func TestAFailedActionWalksNoChain(t *testing.T) {
 		return resource.New("id", kindServer, resource.Tenant{Provider: Name}, state, now)
 	}
 
-	for _, settled := range []string{"running", "stopped", "stopped in place"} {
-		r := res(settled)
-		transitionTo(r, "stopped", settled, "stopping", "starting")
+	// An action that MOVED, which is what a chain describes: `from` and
+	// `settled` differ. Written as pairs rather than as a list of destinations
+	// against one origin, because the origin is half the question — the same
+	// destination is a journey from one state and a no-op from another.
+	for _, moved := range []struct{ from, settled string }{
+		{"stopped", "running"},          // a poweron that booted
+		{"running", "stopped"},          // a poweroff that stopped it
+		{"running", "stopped in place"}, // a poweroff that kept the machine
+	} {
+		r := res(moved.settled)
+		transitionTo(r, moved.from, moved.settled, "stopping", "starting")
 		if len(r.Pending) == 0 {
-			t.Errorf("a %s action pushed no chain, so a client waiting on it observes nothing", settled)
+			t.Errorf("a %s→%s action pushed no chain, so a client waiting on it observes nothing",
+				moved.from, moved.settled)
 		}
-		if r.State != settled {
-			t.Errorf("a %s action left the resource at %q", settled, r.State)
+		if r.State != moved.settled {
+			t.Errorf("a %s→%s action left the resource at %q", moved.from, moved.settled, r.State)
 		}
 	}
 
 	// The failed states the machine layer produces. Whatever they are called,
 	// they are not states this chain knows how to arrive at.
-	for _, failed := range []string{"failed", "starting", "unknown", ""} {
+	//
+	// `stopped` is in this list and was not, which is the whole of #738: this
+	// pack's FailedState IS `stopped` (machines.go), so a start that failed
+	// settles where it started, and the check on the settled value alone cannot
+	// see it. Measured 2026-09-07 before the fix: a poweron whose Start fails
+	// answered [starting stopped stopped stopped].
+	for _, failed := range []string{"failed", "starting", "unknown", "", "stopped"} {
 		r := res(failed)
 		transitionTo(r, "stopped", failed, "stopping", "starting")
 		if len(r.Pending) != 0 {

--- a/tools/falsify/specs/observable-transitions.json
+++ b/tools/falsify/specs/observable-transitions.json
@@ -21,6 +21,14 @@
       "find": "\tif settled != \"running\" && settled != \"stopped\" && settled != \"stopped in place\" {",
       "replace": "\tif settled != \"running\" && settled != \"stopped\" && settled != \"stopped in place\" && false {",
       "test": "TestAFailedActionWalksNoChain"
+    },
+    {
+      "label": "an action that settled where it started walks a chain anyway, so a poweron whose Start failed narrates `starting` for a boot that never happened (#738)",
+      "file": "internal/providers/scaleway/servers.go",
+      "package": "./internal/providers/scaleway/",
+      "find": "\tif settled == from {",
+      "replace": "\tif settled == from && false {",
+      "test": "TestAFailedPoweronWalksNoChain"
     }
   ]
 }


### PR DESCRIPTION
Under `--consistency eventual`, a poweron whose runtime Start failed answered
four reads with `[starting stopped stopped stopped]`, and the task it returned
said `success`. A client watching the action saw a boot that never happened.

CLAUDE.md names this defect for this exact layer: "L'état publié est celui que
l'effet a produit, pas celui que l'intention visait. Un start qui a échoué rend
FailedState ; répondre « running » parce que la requête demandait poweron est le
mensonge exact que ce projet existe pour éviter." `starting` is that lie one
step earlier in the chain.

WHY THE GUARD DID NOT SEE IT.

`transitionTo` refused any settled value outside `running`, `stopped` and
`stopped in place`. This pack's FailedState IS `stopped` — machines.go says why,
"Scaleway declares no error state for a server either" — so a start that failed
landed on an allowed value and the chain was narrated from an action that had
not moved.

The rule is now written where the knowledge is: an action that settles where it
started made no journey, and a chain describes a journey. The exception already
had its own door and keeps it — `transitionBackTo`, where returning to the
starting state is the point (a reboot leaves `running` and comes back to it) and
where the chain is the action's only signal. It no longer goes through
`transitionTo`, so the refusal cannot swallow it.

WHY THE TEST DID NOT CATCH IT, AND THIS IS THE PART WORTH READING.

`TestAFailedActionWalksNoChain` had two halves and both were wrong about the
same value. Its refusing half listed `failed`, `starting`, `unknown` and `""` —
none of which this layer produces. Its accepting half looped over `running`,
`stopped` and `stopped in place` against a single `from = "stopped"`, so it
REQUIRED a chain for `from == settled == "stopped"`: the failed poweron itself.
The test asserted the defect in one half and missed it in the other, over a
population that excluded the only value that occurs.

The accepting half now names journeys rather than destinations against one
origin — `stopped→running`, `running→stopped`, `running→stopped in place` —
because the origin is half the question: the same destination is a journey from
one state and a no-op from another. The refusing half gains `stopped`.

TestAFailedPoweronWalksNoChain drives the whole path through HTTP on an eventual
store, with a runtime whose Start fails and no machine started. It fails without
this change, on read 1, answering `starting`. It is at the API level on purpose:
the unit guard was already believed to hold, and only the whole path showed it.

The falsify spec gains a fourth mutation on the new refusal; all four compile
and bite, green after restoration.

This also makes true a sentence #637's changelog entry already claimed — "a
failed action walks no chain" — which was written as an intention and was not
one. The entry added here says which change made it so.

Closes #738

Assisted-by: Claude Code (claude-opus-5)

## Checks

- `mise run prepush` exits 0
- `mise run falsify -- tools/falsify/specs/observable-transitions.json` : four mutations, all `compiled=yes` and all `the test bit`, green after restoration
- No runtime run: this path never reaches a machine, and the test's runtime refuses to start one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
