### PR TITLE
chore(drift): triage DetachAndDeletePrivateNetworkInterface, which upstream just wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,12 +862,12 @@ what this emulator serves, declines on purpose, or has not triaged yet.
 
 #### Scaleway
 
-191 routes mounted. Of the 535 operations upstream declares: 35% served,
+191 routes mounted. Of the 536 operations upstream declares: 35% served,
 64% declined on purpose, 0% untriaged.
 
 | Group | Served | Declined | Untriaged | Upstream |
 |---|--:|--:|--:|--:|
-| `instance` | 71 | 79 | 0 | 150 |
+| `instance` | 71 | 80 | 0 | 151 |
 | `lb` | 42 | 65 | 0 | 107 |
 | `iam` | 5 | 78 | 0 | 83 |
 | `vpcgw` | 15 | 49 | 0 | 64 |
@@ -876,7 +876,7 @@ what this emulator serves, declines on purpose, or has not triaged yet.
 | `block` | 22 | 5 | 0 | 27 |
 | `account` | 5 | 7 | 0 | 12 |
 | *… 2 smaller groups* | 10 | 8 | 0 | 18 |
-| **Total** | **191** | **344** | **0** | **535** |
+| **Total** | **191** | **345** | **0** | **536** |
 
 #### Exoscale
 

--- a/coverage/contract-only.json
+++ b/coverage/contract-only.json
@@ -31,11 +31,6 @@
         "operation": "instance/v1.SetVolume",
         "status": "backlog",
         "reason": "the PUT whole-object sibling of UpdateVolume, which this pack serves. Reachable only by a client generated from the portal document, never by scaleway-sdk-go"
-      },
-      {
-        "operation": "instance/v2alpha1.DetachAndDeletePrivateNetworkInterface",
-        "status": "backlog",
-        "reason": "POST .../private-network-interfaces/{id}/detach-and-delete, in the portal document on 2026-09-06 and not wrapped by scaleway-sdk-go at cb7f357, so no client built on the SDK (scw, the Terraform provider) can reach it yet; surfaced by the contract refresh #631 made. The pack serves this family: the v2alpha1 reads (privatenics_v2alpha1.go) and the v1 detach. The day the SDK wraps it, the scan puts it in front of the triage"
       }
     ]
   }

--- a/coverage/scaleway-coverage.json
+++ b/coverage/scaleway-coverage.json
@@ -1,8 +1,8 @@
 {
   "provider": "scaleway",
-  "total": 535,
+  "total": 536,
   "implemented": 191,
-  "declined": 344,
+  "declined": 345,
   "unknown": 0,
   "orphans": null,
   "products": [
@@ -86,9 +86,9 @@
     },
     {
       "product": "instance",
-      "total": 150,
+      "total": 151,
       "implemented": 71,
-      "declined": 79,
+      "declined": 80,
       "unknown": 0,
       "versions": [
         {
@@ -100,9 +100,9 @@
         },
         {
           "version": "v2alpha1",
-          "total": 72,
+          "total": 73,
           "implemented": 10,
-          "declined": 62,
+          "declined": 63,
           "unknown": 0
         }
       ]
@@ -233,9 +233,9 @@
     },
     {
       "group": "instance",
-      "total": 150,
+      "total": 151,
       "implemented": 71,
-      "declined": 79,
+      "declined": 80,
       "unknown": 0
     },
     {
@@ -1972,6 +1972,13 @@
       "operation": "instance/v2alpha1/API.DeleteUserData",
       "product": "instance",
       "reason": "instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces and placement groups onto it, which is why those two families are served and these are not",
+      "version": "v2alpha1",
+      "status": "declined"
+    },
+    {
+      "operation": "instance/v2alpha1/API.DetachAndDeletePrivateNetworkInterface",
+      "product": "instance",
+      "reason": "instance/v2alpha1.DetachAndDeletePrivateNetworkInterface folds a detach and a delete into one call, and no client this project drives sends it: the recorded transcript of a full Terraform apply on provider 2.81.0 shows only ListPrivateNetworkInterfaces on this API. The two halves it folds are reachable through the routes already mounted, and the alpha version is named so a promotion to a stable instance/v2 has this decided again",
       "version": "v2alpha1",
       "status": "declined"
     },

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -407,7 +407,7 @@ reason that outlived its cause.
 - `ipam` — 1 operation — no official client calls it: the CLI has no detach subcommand, and the provider detaches by deleting the NIC that carries the address
 - `vpc` — 1 operation — no official client asks for the flat list: `scw vpc` has no subnet subcommand, and the Terraform provider reads the subnets a private network publishes inline through GetPrivateNetwork
 
-### Declined on purpose (344)
+### Declined on purpose (345)
 
 Operations this pack knowingly does not serve, and why. Declining is a
 decision the drift gate records, which is what separates it from having
@@ -435,6 +435,7 @@ are in `coverage/`, one artefact per provider.
 - `instance` — 2 operations — it mounts Scaleway's File Storage product, and there is no filesystem service behind this emulator for a machine to mount
 - `instance` — 2 operations — the SDK's hand-written helpers, deprecated upstream in favour of AttachServerVolume and DetachServerVolume, which this pack serves and which the CLI calls
 - `instance` — 2 operations — there is no legacy storage behind this emulator to migrate from, so a plan would describe a move between two things that are the same store
+- `instance` — 1 operation — instance/v2alpha1.DetachAndDeletePrivateNetworkInterface folds a detach and a delete into one call, and no client this project drives sends it: the recorded transcript of a full Terraform apply on provider 2.81.0 shows only ListPrivateNetworkInterfaces on this API. The two halves it folds are reachable through the routes already mounted, and the alpha version is named so a promotion to a stable instance/v2 has this decided again
 - `instance` — 1 operation — it hands an instance flexible IP over to IPAM's pool, and the public addresses of this emulator live and die with the instance product: IPAM here holds private-network addresses only
 - `instance` — 1 operation — it writes into Object Storage, which is not emulated because the Terraform provider builds the S3 endpoint in code: supporting it needs DNS interception and a certificate, measured in docs/limits.md
 - `instance` — 1 operation — no recording of /products/volumes exists in corpus/, and the route answers a table of per-type constraints that would have to be invented rather than measured

--- a/internal/cli/contract_only_test.go
+++ b/internal/cli/contract_only_test.go
@@ -23,9 +23,11 @@ func TestContractOnlyOperationsAreTriaged(t *testing.T) {
 		"instance/v1.SetSecurityGroupRule",
 		"instance/v1.SetSnapshot",
 		"instance/v1.SetVolume",
-		// In the portal document on 2026-09-06 and not in scaleway-sdk-go at
-		// cb7f357; surfaced by the contract refresh #631 made.
-		"instance/v2alpha1.DetachAndDeletePrivateNetworkInterface",
+		// instance/v2alpha1.DetachAndDeletePrivateNetworkInterface used to sit
+		// here: in the portal document on 2026-09-06 and not in scaleway-sdk-go
+		// at cb7f357. The nightly scan of 2026-09-10 found it wrapped upstream,
+		// so the exemption covered nothing and left with it. It is now triaged
+		// where every other operation is, in the pack's Declined().
 	}
 
 	problems, err := contractOnlyGaps(record, "scaleway", only)

--- a/internal/providers/scaleway/pack.go
+++ b/internal/providers/scaleway/pack.go
@@ -1180,6 +1180,27 @@ func (p *Pack) Declined() []emulator.Decline {
 		// upstream adds here, and the point of this file is that additions are
 		// seen. When the surface stabilises into an instance/v2, the scan
 		// reports it as new and this decision gets taken again.
+		// Appeared upstream in the nightly scan of 2026-09-10, in a family this
+		// pack DOES serve, which is why it gets its own reason rather than
+		// joining the blanket one below: that reason says private network
+		// interfaces are served, and it would read as a contradiction here.
+		//
+		// It is a convenience that folds two calls into one, and this pack already
+		// answers the second half: DeletePrivateNetworkInterface is mounted, and
+		// the store is shared with instance/v1, so a client that detaches then
+		// deletes gets the right outcome through the doors that exist. What no
+		// measurement shows is anybody calling the folded form: the `feint proxy`
+		// transcript of a full Terraform apply on provider 2.81.0 recorded exactly
+		// one v2alpha1 interface operation, ListPrivateNetworkInterfaces, and
+		// privatenics_v2alpha1.go carries that recording.
+		//
+		// Serving it anyway would be surface nothing drives, which is the trade
+		// this repository refuses on purpose. The alpha version is named so a
+		// promotion to a stable instance/v2 reports it as new and this decision is
+		// taken again.
+		emulator.Because("instance/v2alpha1.DetachAndDeletePrivateNetworkInterface folds a detach and a delete into one call, and no client this project drives sends it: the recorded transcript of a full Terraform apply on provider 2.81.0 shows only ListPrivateNetworkInterfaces on this API. The two halves it folds are reachable through the routes already mounted, and the alpha version is named so a promotion to a stable instance/v2 has this decided again",
+			"instance/v2alpha1/API.DetachAndDeletePrivateNetworkInterface"),
+
 		emulator.Because("instance/v2alpha1 is an alpha rewrite Scaleway is still free to change, and no client this project drives reaches for these operations — a claim that held for the whole API until provider 2.81.0 moved private network interfaces and placement groups onto it, which is why those two families are served and these are not",
 			"instance/v2alpha1/VolumeAPI.CreateSnapshot",
 			"instance/v2alpha1/VolumeAPI.CreateVolume",


### PR DESCRIPTION
# Summary

The nightly scan found `instance/v2alpha1/API.DetachAndDeletePrivateNetworkInterface`
untriaged. `drift:check` exited 2 on **every** branch, so nothing could be pushed
until this landed.

**Triaged as declined**, and it gets its own reason rather than joining the
blanket `instance/v2alpha1` one. That blanket reason says private network
interfaces *are* served, which is true, and this operation belongs to that
family: filing it underneath would read as a contradiction.

The precise reason, which is a measurement rather than a preference:

- the operation folds a detach and a delete into one call;
- **both halves are already reachable** through routes this pack mounts
  (`DeletePrivateNetworkInterface`), and the store is shared with `instance/v1`;
- **no client this project drives sends the folded form**. The `feint proxy`
  transcript of a full Terraform apply on provider 2.81.0 recorded exactly one
  v2alpha1 interface operation, and it is `List`. `privatenics_v2alpha1.go`
  carries that recording;
- the alpha version is named in the reason so a promotion to a stable
  `instance/v2` reports it as new and has this decided again.

The operation also carried a **contract-only exemption**, recorded when the
portal document declared it and `scaleway-sdk-go` did not. The SDK wraps it now,
so the exemption covered nothing and left.

## The part worth reading before the next drift PR

This looked like two gates contradicting each other, and it is not: the
operation lives in **three** places, not two.

| file | what it holds |
|---|---|
| `internal/providers/scaleway/pack.go` | the triage decision |
| `coverage/contract-only.json` | the exemption, now stale |
| `internal/cli/contract_only_test.go` | the expected list, **written in the test body** and not derived from any scan |

Removing the exemption without the test's list turns `drift:check` green and
that test red. Leaving both turns the pair inverted. A first attempt touched two
of the three and read the result as an unresolvable conflict.

**The order that works:** triage first, `mise run drift:update` second so the
regenerated coverage knows the operation, remove the exemption third.

## Type of change

- [x] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes — and `mise run prepush` in full, which is what was
      red before this
- [x] No new external Go dependency
- [x] `internal/core` still knows no provider
- [x] Nothing in the diff could be written identically for another provider
- [x] `mise run testplan` was run. It asks for `conformance:leg -- fields` on a
      pack change; **it was not played, deliberately, and here is why**: this
      change mounts no route and alters no handler. It adds one string to
      `Declined()` and removes one stale exemption. No response any client can
      observe differs before and after, so the leg would re-prove the previous
      commit. The metrics pull request that follows this one carries the same
      note for its own reason.

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] N/A on `mise run conformance` for the reason stated above: no route, no
      handler, no observable response changed. Stating it rather than leaving the
      box blank, because a run not played is written down here.
- [x] Every name in the diff comes from `scaleway-sdk-go`
      (`api/instance/v2alpha1/instance_sdk.go:5262`), read directly

### When a route is added or changed

N/A — no route added or changed. `mise run drift:update` was run and `coverage/`
is committed with the change, along with the `README.md` and `docs/routes.md` it
regenerated.

### When behaviour a client can observe changes

N/A — none does.

### When `.github/workflows/` is touched

N/A.

### When a machine runtime is involved

N/A.

## Related issues

Unblocks `drift:check` for every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
