### PR TITLE
feat(metrics): measure release downloads from the only counter GitHub serves

### DIFF
--- a/.github/workflows/adoption-metrics.yml
+++ b/.github/workflows/adoption-metrics.yml
@@ -1,0 +1,100 @@
+name: adoption-metrics
+
+# One snapshot a day of what GitHub says was downloaded, appended to a history
+# that lives on its own branch.
+#
+# WHY NOT main. The `main` ruleset carries `pull_request` and
+# `required_status_checks`, and its only bypass is scoped to a pull request, so
+# a daily `git push origin main` is refused outright. The alternative inside
+# main would be a pull request a day, each one having to pass the full required
+# suite to land a row of numbers, which is neither cheap nor reviewable. So the
+# data lives on the orphan `metrics` branch: no noise in main's history, the
+# full history kept, and metrics/feint-latest.json reachable as a raw URL for
+# whatever renders it later. This is the gh-pages arrangement, for the same
+# reason gh-pages exists.
+#
+# WHAT IT NEVER DOES. It reads a public counter and writes a CSV. feint itself
+# phones nobody, and nothing here identifies a person: see
+# docs/adoption-metrics.md, which also says why download_count is not a user
+# count.
+
+on:
+  schedule:
+    # 04:17 UTC. Not on the hour, because everybody schedules on the hour and
+    # GitHub delays a busy minute.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adoption-metrics
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      # The only job that writes, and it writes to one branch that carries no
+      # code. main is unreachable from here: its ruleset refuses a direct push.
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout the collector
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+          cache: false
+
+      # The data branch, in a directory of its own. It carries no code, only
+      # metrics/, and it is expected to exist: it was seeded with the first
+      # snapshot when this workflow was added. A missing branch fails the run
+      # here rather than silently starting a second, parallel history.
+      #
+      # persist-credentials: false on both checkouts, like drift.yml, which
+      # pushes a branch the same way: the push authenticates through GH_TOKEN
+      # and the runner's gh credential helper rather than through a token left
+      # behind in .git/config, which zizmor's artipacked audit flags.
+      - name: Checkout the data branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: metrics
+          path: data
+          persist-credentials: false
+
+      - name: Collect today's snapshot
+        env:
+          # Unauthenticated calls are capped at 60/hour per IP, which a shared
+          # runner exhausts. This raises it to 1000 for this repository, and the
+          # endpoint it reads is public either way.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./tools/metrics collect --dir data/metrics
+
+      - name: Commit, only if something moved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd data
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add metrics
+          if git diff --cached --quiet; then
+            echo "no change; nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore(metrics): update adoption metrics $(date -u +%F)"
+          git push origin metrics
+
+      - name: Say what it found
+        run: go run ./tools/metrics report --dir data/metrics

--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,8 @@ crash.*.log
 
 # Site mockups, the maintainer's own work in progress
 maquettes-site/
+
+# Adoption snapshots live on the `metrics` branch, never in main.
+# docs/adoption-metrics.md says why.
+/metrics/
+/.metrics/

--- a/docs/adoption-metrics.md
+++ b/docs/adoption-metrics.md
@@ -1,0 +1,148 @@
+# Release download metrics
+
+[docs/adoption.md](adoption.md) asks the question that decides whether a 1.0
+means anything: **does anybody other than the author run this?** Its scoreboard
+counts configurations that apply, issues opened by strangers, providers that
+mention the project. Every one of those measures a decision somebody made.
+
+This page counts something weaker and says so plainly: **how many times a
+published binary was fetched.** It is a useful number and a poor proxy, and the
+two pages are kept apart so the poor proxy never gets read as the good one.
+
+## What is measured
+
+GitHub publishes a `download_count` on every release asset. Once a day, a
+workflow reads all of them, keeps the four that are the software, and appends a
+row per asset to an append-only CSV.
+
+The four binaries, and nothing else:
+
+```text
+feint-linux-amd64
+feint-linux-arm64
+feint-darwin-amd64
+feint-darwin-arm64
+```
+
+## What is not measured, and why the distinction is not pedantic
+
+**`download_count` counts downloads. It never counts people.** One CI job that
+runs hourly outweighs a hundred humans, and the gap is not hypothetical here.
+Measured on 2026-09-09:
+
+| | downloads |
+|---|---|
+| the four binaries, together | 1 254 |
+| `checksums.txt` alone | 1 264 |
+
+`checksums.txt` is fetched slightly **more** often than every binary combined.
+Nobody reads a checksum file for pleasure: that is the signature of an install
+script verifying before it runs, which is exactly what
+[setup-feint](https://github.com/marketplace/actions/set-up-feint) does. Add
+that `linux-amd64` is 96.3% of the total, and the shape of the traffic is a
+fleet of runners, not a crowd of laptops.
+
+**That is information, not noise.** A pipeline that installs feint every day is
+a real use, and arguably a better one than a download somebody forgot about. It
+is simply not a user count, so this page never writes one.
+
+So: **"1 254 binary downloads"**. Never "1 254 users", never "1 254
+installations".
+
+## What is excluded from the total
+
+Companion files are published beside every release and are deliberately not
+counted: `checksums.txt`, `checksums.txt.cosign.bundle`, `sbom.cdx.json`,
+`provenance.intoto.jsonl`.
+
+Summing every asset would have reported **2 600** instead of 1 254 on
+2026-09-09, an overstatement of 107%.
+
+The filter is two explicit lists, not one. An asset matching neither
+`binary_patterns` nor `ignore_patterns` **stops the collection** and names
+itself, because the alternative is worse than a failure: the day the release
+workflow adds `feint-windows-amd64` or renames an asset, a permissive filter
+would report a smaller number, and a smaller number reads exactly like a drop in
+adoption. This is the same decision `Declined()` makes for an unserved API
+operation, for the same reason.
+
+## What cannot be recovered, ever
+
+GitHub serves the **current** counter and never its history. There is no
+endpoint for "how many downloads had v0.12.1 accumulated on 3 September".
+
+So a release's J+1, J+7 and J+30 exist only where the corresponding day fell
+**after** collection started. Collection started on 2026-09-10:
+
+- for v0.12.1, published on 2026-09-01, J+1 and J+7 are gone for good, while
+  J+30 (1 October) is simply a snapshot away;
+- for every release cut from now on, the three points will exist.
+
+The report omits a point it cannot measure rather than printing a zero, and the
+same rule governs `downloads_1d`, `downloads_7d` and `downloads_30d`: a window
+no snapshot is old enough to close is absent, because "nothing was downloaded in
+30 days" and "this tool has not been collecting for 30 days" are opposite facts
+and a zero states the first while meaning the second.
+
+## Where the data lives
+
+On the **`metrics` branch**, not on `main`. The `main` ruleset carries
+`pull_request` and `required_status_checks`, so a daily automated push to it is
+refused; a pull request a day to land a row of numbers would be worse. The
+orphan branch keeps main's history clean and the metrics history complete.
+
+```text
+metrics/feint-release-downloads.csv    append-only, one row per asset per day
+metrics/feint-latest.json              the computed figures, for whatever renders them
+```
+
+The CSV columns are `date,version,asset,os,arch,downloads,published_at`.
+
+## Reproducing the figures locally
+
+Every number on this page comes from the CSV, so anybody holding it can
+recompute them. Nothing is stored that the report cannot rebuild.
+
+```bash
+git fetch origin metrics
+git worktree add .metrics metrics
+mise run metrics:report -- --dir .metrics/metrics
+mise run metrics:report -- --dir .metrics/metrics --json
+```
+
+To take a snapshot by hand, which is the same code the workflow runs:
+
+```bash
+mise run metrics:collect -- --dir .metrics/metrics
+```
+
+## Adding another project
+
+The collector holds no knowledge of feint. A second project is a JSON file:
+
+```json
+{
+  "project": "pepin",
+  "repository": "stephrobert/pepin",
+  "binary_patterns": ["^pepin-(?P<os>linux|darwin)-(?P<arch>amd64|arm64)$"],
+  "ignore_patterns": ["^checksums\\.txt$", "^sbom\\.cdx\\.json$"]
+}
+```
+
+The named groups `os` and `arch` are how a platform breakdown happens without
+the collector knowing any project's naming scheme. A project that encodes no
+platform in its asset names simply declares no groups and gets totals and
+per-version figures.
+
+```bash
+go run ./tools/metrics collect --config tools/metrics/projects/pepin.json
+```
+
+## What was deliberately not built
+
+No telemetry in feint. The binary calls nobody, generates no identifier, and
+reads no IP, hostname or repository. Everything on this page comes from a public
+counter GitHub already publishes, read from outside by a scheduled job.
+
+That is a smaller measurement than telemetry would give, and it is the one that
+does not require asking anybody to trust a promise.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -145,6 +145,15 @@ Stars measure attention. These measure use, and each one is checkable by anybody
 most valuable line on this page, and hiding it would turn the whole exercise into
 a marketing claim — which is the one thing this repository is built not to be.
 
+Release download counts are measured too, and they are deliberately **not** in
+the table above. Every signal there records a decision somebody made; a download
+records that a file moved, and on this repository the evidence says most of them
+move for a CI runner rather than a person — `checksums.txt` is fetched slightly
+more often than every binary combined. That is a real use and worth tracking, so
+it is tracked, one page over and under its own name:
+[docs/adoption-metrics.md](adoption-metrics.md), which says what the figure
+does and does not license anybody to claim.
+
 ## The list
 
 Empty, as of 2026-08-17. The first entry will be somebody else's.

--- a/mise.toml
+++ b/mise.toml
@@ -158,6 +158,26 @@ depends = ["build"]
 # sending any of it.
 run = "tools/corpus/cloud.sh ./feint"
 
+# ---- Adoption ---------------------------------------------------------------------------------
+[tasks."metrics:report"]
+description = "What GitHub says was downloaded, from the snapshots already taken"
+# Offline: it reads metrics/ and computes, it does not call GitHub. The daily
+# snapshot is .github/workflows/adoption-metrics.yml's job, and the data lives
+# on the `metrics` branch because main's ruleset refuses a direct push.
+#
+#   git fetch origin metrics && git worktree add .metrics metrics
+#   mise run metrics:report -- --dir .metrics/metrics
+#
+# download_count counts downloads, never people. docs/adoption-metrics.md says
+# what that does and does not license anybody to claim.
+run = "go run ./tools/metrics report"
+
+[tasks."metrics:collect"]
+description = "Take one snapshot of the release download counters (calls the GitHub API)"
+# The one task here that reaches the network. It is the same code the scheduled
+# workflow runs, so a figure can always be reproduced by hand.
+run = "go run ./tools/metrics collect"
+
 # ---- Upstream tracking (the anti-drift loop) --------------------------------------------------
 [tasks."upstream:sync"]
 description = "Fetch the upstream SDKs and API descriptions the scan and the contracts read"

--- a/tools/metrics/adoption_test.go
+++ b/tools/metrics/adoption_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// buildHistory appends one snapshot per given day, each carrying the counters
+// that day's map names. A version absent from the map is absent from that
+// snapshot, which is how a release that does not exist yet is expressed.
+func buildHistory(t *testing.T, days []struct {
+	day    string
+	counts map[string]int
+}, published map[string]string) *History {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "d.csv")
+	cfg := testConfig(t)
+	for _, d := range days {
+		var rels []Release
+		for v, n := range d.counts {
+			rels = append(rels, release(v, published[v], n, 0, 0, 0))
+		}
+		snap, err := Parse(cfg, rels, d.day)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Append(path, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h, err := ReadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// TestAdoptionOmitsOnlyThePointsThatFellBeforeCollection is the whole
+// availability rule, and it is decided per point rather than per release.
+//
+// v0.12.1 was published on 2026-09-01 and collection starts on 2026-09-10: its
+// J+1 (the 2nd) and J+7 (the 8th) are unrecoverable, while its J+30 (the 1st of
+// October) is simply a snapshot away. A rule written per release would have
+// thrown all three away.
+func TestAdoptionOmitsOnlyThePointsThatFellBeforeCollection(t *testing.T) {
+	published := map[string]string{"v0.12.1": "2026-09-01"}
+	days := []struct {
+		day    string
+		counts map[string]int
+	}{
+		{"2026-09-10", map[string]int{"v0.12.1": 376}},
+		{"2026-10-01", map[string]int{"v0.12.1": 402}},
+	}
+	h := buildHistory(t, days, published)
+	now, _ := time.Parse("2006-01-02", "2026-10-01")
+	rep := Build("feint", h, now)
+
+	curve := rep.Adoption["v0.12.1"]
+	if curve == nil {
+		t.Fatal("no curve at all for a release whose J+30 is measurable")
+	}
+	if _, ok := curve["J+1"]; ok {
+		t.Error("J+1 was published for a date that passed before collection started")
+	}
+	if _, ok := curve["J+7"]; ok {
+		t.Error("J+7 was published for a date that passed before collection started")
+	}
+	if got := curve["J+30"]; got != 402 {
+		t.Errorf("J+30 is %d, want 402: a release's cumulative counter on day 30 IS its adoption at J+30", got)
+	}
+}
+
+// TestAdoptionIsTheCumulativeCounterWithNothingSubtracted. A release's counter
+// starts at zero when it is published, so subtracting a later origin reading
+// would erase whatever it earned before the first snapshot that saw it.
+func TestAdoptionIsTheCumulativeCounterWithNothingSubtracted(t *testing.T) {
+	published := map[string]string{"v0.14.0": "2026-09-11"}
+	days := []struct {
+		day    string
+		counts map[string]int
+	}{
+		{"2026-09-10", map[string]int{}},               // before it exists
+		{"2026-09-12", map[string]int{"v0.14.0": 20}},  // J+1
+		{"2026-09-18", map[string]int{"v0.14.0": 90}},  // J+7
+		{"2026-10-11", map[string]int{"v0.14.0": 347}}, // J+30
+	}
+	// The first day carries no release at all, which Parse refuses; give it one
+	// other release so the snapshot is legal.
+	days[0].counts = map[string]int{"v0.13.0": 7}
+	published["v0.13.0"] = "2026-09-07"
+
+	h := buildHistory(t, days, published)
+	now, _ := time.Parse("2006-01-02", "2026-10-11")
+	rep := Build("feint", h, now)
+
+	curve := rep.Adoption["v0.14.0"]
+	if curve == nil {
+		t.Fatal("no curve for a release published after collection started")
+	}
+	for point, want := range map[string]int{"J+1": 20, "J+7": 90, "J+30": 347} {
+		if got := curve[point]; got != want {
+			t.Errorf("%s is %d, want %d", point, got, want)
+		}
+	}
+}
+
+// TestAStaleSnapshotDoesNotAnswerForAMissedPoint: a month-long gap in
+// collection must not let a later reading wear J+7's label.
+func TestAStaleSnapshotDoesNotAnswerForAMissedPoint(t *testing.T) {
+	published := map[string]string{"v1.0.0": "2026-09-11"}
+	days := []struct {
+		day    string
+		counts map[string]int
+	}{
+		{"2026-09-10", map[string]int{"v1.0.0": 0}},
+		{"2026-11-20", map[string]int{"v1.0.0": 5000}}, // the job was down for two months
+	}
+	h := buildHistory(t, days, published)
+	now, _ := time.Parse("2006-01-02", "2026-11-20")
+	rep := Build("feint", h, now)
+
+	if n, ok := rep.Adoption["v1.0.0"]["J+7"]; ok {
+		t.Errorf("J+7 answered %d from a snapshot 63 days late", n)
+	}
+}

--- a/tools/metrics/config.go
+++ b/tools/metrics/config.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// Config names one project's release assets, so the same collector serves
+// feint, pepin and pavois without a line of code changing.
+//
+// JSON rather than YAML, for two reasons that both come from this repository:
+// the zero-dependency rule (rule 6) leaves no YAML parser in reach, and every
+// other configured artefact here is already JSON (coverage/, contracts/,
+// tools/falsify/specs/, docs/limits-acks.json). A hand-rolled YAML subset would
+// be a dependency written in-house, which is the worst of the two.
+type Config struct {
+	// Project is the short name the reports carry.
+	Project string `json:"project"`
+	// Repository is owner/name on GitHub.
+	Repository string `json:"repository"`
+
+	// BinaryPatterns match the assets that ARE the software. Each may carry
+	// the named groups `os` and `arch`, which is how a report splits platforms
+	// without the collector knowing any project's naming scheme:
+	//
+	//	^feint-(?P<os>linux|darwin)-(?P<arch>amd64|arm64)$
+	BinaryPatterns []string `json:"binary_patterns"`
+
+	// IgnorePatterns match the assets that are deliberately NOT counted:
+	// checksums, signatures, SBOM, provenance. They are listed rather than
+	// inferred, and that is the whole point of the design.
+	IgnorePatterns []string `json:"ignore_patterns"`
+}
+
+// Kind is what an asset was classified as.
+type Kind int
+
+const (
+	// KindUnknown is an asset that matched neither list. It is an error, never
+	// a silent zero. See Classify.
+	KindUnknown Kind = iota
+	// KindBinary is the software itself, and the only thing that is counted.
+	KindBinary
+	// KindIgnored is a declared companion file.
+	KindIgnored
+)
+
+// compiled holds a Config with its patterns compiled once.
+type compiled struct {
+	cfg    Config
+	binary []*regexp.Regexp
+	ignore []*regexp.Regexp
+}
+
+// LoadConfig reads and validates one project's description.
+func LoadConfig(path string) (*compiled, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var cfg Config
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return cfg.compile()
+}
+
+func (c Config) compile() (*compiled, error) {
+	switch {
+	case c.Project == "":
+		return nil, fmt.Errorf("the configuration names no project")
+	case c.Repository == "":
+		return nil, fmt.Errorf("the configuration names no repository")
+	case len(c.BinaryPatterns) == 0:
+		// A collector with no binary pattern would classify every asset as
+		// unknown and report nothing, which is a silent zero wearing a
+		// configuration's clothes.
+		return nil, fmt.Errorf("the configuration lists no binary_patterns, so nothing would ever be counted")
+	}
+	out := &compiled{cfg: c}
+	for _, p := range c.BinaryPatterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("binary_patterns: %q: %w", p, err)
+		}
+		out.binary = append(out.binary, re)
+	}
+	for _, p := range c.IgnorePatterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("ignore_patterns: %q: %w", p, err)
+		}
+		out.ignore = append(out.ignore, re)
+	}
+	return out, nil
+}
+
+// Classify answers what an asset is, and refuses to guess.
+//
+// The refusal is the mechanism, not a courtesy. A filter that only selects what
+// it recognises reports a smaller number the day the release workflow starts
+// publishing `feint-windows-amd64` or renames an asset, and a smaller number
+// reads exactly like a drop in adoption. Here an asset that matched neither
+// list stops the collection and says its name, so the packaging change is
+// triaged by a human the way `Declined()` makes an unserved operation a
+// decision rather than a silence.
+//
+// TestAnUnexpectedAssetStopsTheCollection fails without this.
+func (c *compiled) Classify(name string) Kind {
+	for _, re := range c.binary {
+		if re.MatchString(name) {
+			return KindBinary
+		}
+	}
+	for _, re := range c.ignore {
+		if re.MatchString(name) {
+			return KindIgnored
+		}
+	}
+	return KindUnknown
+}
+
+// Platform reads the `os` and `arch` named groups out of whichever binary
+// pattern matched. Both are empty when the pattern declares no groups, which is
+// allowed: a project that does not encode a platform in its asset names still
+// gets totals and per-version figures.
+func (c *compiled) Platform(name string) (goos, arch string) {
+	for _, re := range c.binary {
+		m := re.FindStringSubmatch(name)
+		if m == nil {
+			continue
+		}
+		for i, group := range re.SubexpNames() {
+			switch group {
+			case "os":
+				goos = m[i]
+			case "arch":
+				arch = m[i]
+			}
+		}
+		return goos, arch
+	}
+	return "", ""
+}

--- a/tools/metrics/github.go
+++ b/tools/metrics/github.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// maxPages caps the pagination walk. 100 releases per page, so this is 10 000
+// releases: far beyond any project this serves, and a bound is what keeps a
+// misbehaving API from turning a scheduled job into an unbounded loop.
+const maxPages = 100
+
+// apiBase is a variable rather than a constant so the pagination walk and the
+// failure paths can be driven against httptest. A collector whose only proof is
+// "it worked against github.com once" has no test for the page-100 boundary or
+// for a 503, which are exactly the two that matter on a scheduled job.
+var apiBase = "https://api.github.com"
+
+// FetchReleases reads every release of a repository, following pagination.
+//
+// The token is optional: the endpoint is public and unauthenticated calls work,
+// but they are rate-limited to 60 per hour per IP, which a shared CI runner
+// exhausts. GITHUB_TOKEN raises that to 1 000 for the repository.
+func FetchReleases(repo string) ([]Release, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	var all []Release
+
+	for page := 1; page <= maxPages; page++ {
+		url := fmt.Sprintf("%s/repos/%s/releases?per_page=100&page=%d", apiBase, repo, page)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		req.Header.Set("User-Agent", "feint-adoption-metrics")
+		if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			// The API being unreachable must fail the run rather than write a
+			// snapshot of what was collected so far: a partial snapshot is
+			// indistinguishable from a collapse in downloads once it is in the
+			// CSV, and the CSV is append-only.
+			return nil, fmt.Errorf("GET %s: %w", url, err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET %s: %s: %s", url, resp.Status, snippet(body))
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("GET %s: %w", url, readErr)
+		}
+
+		var batch []Release
+		if err := json.Unmarshal(body, &batch); err != nil {
+			return nil, fmt.Errorf("GET %s: %w", url, err)
+		}
+		if len(batch) == 0 {
+			return all, nil
+		}
+		all = append(all, batch...)
+	}
+	return nil, fmt.Errorf("%s has more than %d pages of releases, which is not credible; refusing a partial read", repo, maxPages)
+}
+
+func snippet(b []byte) string {
+	const max = 200
+	if len(b) > max {
+		return string(b[:max]) + "…"
+	}
+	return string(b)
+}

--- a/tools/metrics/main.go
+++ b/tools/metrics/main.go
@@ -1,0 +1,293 @@
+// Command metrics measures how much of a project's published software is
+// actually downloaded, from the only figure GitHub serves: an asset's
+// download_count.
+//
+// It is deliberately not part of the feint binary. feint emulates clouds; this
+// reads a repository's release page. Folding it in would put an outbound HTTP
+// call to github.com inside the emulator's binary for a subject that has
+// nothing to do with emulation, and docs/adoption-metrics.md promises that
+// feint itself phones nobody.
+//
+//	go run ./tools/metrics collect --config tools/metrics/projects/feint.json
+//	go run ./tools/metrics report  --config tools/metrics/projects/feint.json
+//	go run ./tools/metrics report  --json
+//
+// What it does NOT measure, stated where somebody reading the code will see it:
+// download_count counts downloads, never people. One CI job that runs hourly
+// outweighs a hundred humans, and on this repository the evidence is direct —
+// checksums.txt is downloaded slightly MORE often than every binary combined,
+// which is the signature of an install script verifying before it runs.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	var err error
+	switch os.Args[1] {
+	case "collect":
+		err = collect(os.Args[2:])
+	case "report":
+		err = report(os.Args[2:])
+	case "-h", "--help", "help":
+		usage()
+		return
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "metrics: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage: metrics <collect|report> [flags]
+
+  collect   read the repository's releases and append today's snapshot
+  report    compute the figures from the snapshots already taken
+
+flags:
+  --config <path>   the project description (default tools/metrics/projects/feint.json)
+  --dir <path>      where the data lives (default metrics)
+  --json            report only: machine-readable output
+  --date <date>     collect only: override today, for a replay
+`)
+}
+
+// dataFiles answers the two paths a project's data lives in.
+func dataFiles(dir, project string) (csvPath, jsonPath string) {
+	return filepath.Join(dir, project+"-release-downloads.csv"),
+		filepath.Join(dir, project+"-latest.json")
+}
+
+func collect(args []string) error {
+	fs := flag.NewFlagSet("collect", flag.ExitOnError)
+	cfgPath := fs.String("config", "tools/metrics/projects/feint.json", "the project description")
+	dir := fs.String("dir", "metrics", "where the data lives")
+	date := fs.String("date", "", "override today (YYYY-MM-DD)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, err := LoadConfig(*cfgPath)
+	if err != nil {
+		return err
+	}
+	day := *date
+	if day == "" {
+		day = time.Now().UTC().Format("2006-01-02")
+	}
+
+	releases, err := FetchReleases(cfg.cfg.Repository)
+	if err != nil {
+		return err
+	}
+	if len(releases) == 0 {
+		return fmt.Errorf("%s has no release at all, so there is nothing to measure", cfg.cfg.Repository)
+	}
+
+	snap, err := Parse(cfg, releases, day)
+	if err != nil {
+		return err
+	}
+
+	csvPath, jsonPath := dataFiles(*dir, cfg.cfg.Project)
+	history, err := ReadHistory(csvPath)
+	if err != nil {
+		return err
+	}
+	snap.CompareWith(history.Before(day))
+
+	if err := Append(csvPath, snap); err != nil {
+		return err
+	}
+	// Re-read so the report is built from what was actually written, not from
+	// what this process believes it wrote.
+	history, err = ReadHistory(csvPath)
+	if err != nil {
+		return err
+	}
+	rep := Build(cfg.cfg.Project, history, time.Now())
+	rep.Warnings = append(rep.Warnings, snap.Warnings...)
+	if err := writeJSON(jsonPath, rep); err != nil {
+		return err
+	}
+
+	fmt.Printf("%s: %d binary downloads across %d rows, written to %s\n",
+		day, snap.Total(), len(snap.Rows), csvPath)
+	for _, w := range snap.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	return nil
+}
+
+func writeJSON(path string, rep *Report) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644) //nolint:gosec // a committed, non-secret figure sheet
+}
+
+func report(args []string) error {
+	fs := flag.NewFlagSet("report", flag.ExitOnError)
+	cfgPath := fs.String("config", "tools/metrics/projects/feint.json", "the project description")
+	dir := fs.String("dir", "metrics", "where the data lives")
+	asJSON := fs.Bool("json", false, "machine-readable output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := LoadConfig(*cfgPath)
+	if err != nil {
+		return err
+	}
+	csvPath, _ := dataFiles(*dir, cfg.cfg.Project)
+	history, err := ReadHistory(csvPath)
+	if err != nil {
+		return err
+	}
+	if len(history.Dates) == 0 {
+		return fmt.Errorf("%s holds no snapshot yet; run `metrics collect` first", csvPath)
+	}
+	rep := Build(cfg.cfg.Project, history, time.Now())
+
+	if *asJSON {
+		b, err := json.MarshalIndent(rep, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}
+	printReport(rep, history)
+	return nil
+}
+
+func printReport(rep *Report, h *History) {
+	dates := h.SortedDates()
+	fmt.Printf("%s adoption metrics\n\n", strings.ToUpper(rep.Project[:1])+rep.Project[1:])
+	fmt.Printf("Total binary downloads : %s\n", thousands(rep.TotalBinaryDownloads))
+	fmt.Printf("Latest release         : %s\n", rep.LatestRelease)
+	fmt.Printf("Snapshots              : %d, from %s to %s\n\n", len(dates), dates[0], dates[len(dates)-1])
+
+	if len(rep.Recent) > 0 {
+		fmt.Println("RECENT")
+		for _, k := range []string{"downloads_1d", "downloads_7d", "downloads_30d"} {
+			if v, ok := rep.Recent[k]; ok {
+				fmt.Printf("  %-16s %+d\n", k, v)
+			}
+		}
+		fmt.Println()
+	} else {
+		fmt.Printf("RECENT\n  no window is closed yet: %d snapshot(s) taken, the first on %s\n\n",
+			len(dates), dates[0])
+	}
+
+	fmt.Printf("%-12s %10s\n", "VERSION", "DOWNLOADS")
+	for _, kv := range sortedByValue(rep.Versions) {
+		fmt.Printf("%-12s %10s\n", kv.k, thousands(kv.v))
+	}
+	fmt.Println()
+
+	fmt.Printf("%-20s %10s %8s\n", "PLATFORM", "DOWNLOADS", "%")
+	total := rep.TotalBinaryDownloads
+	for _, kv := range sortedByValue(rep.Platforms) {
+		pct := 0.0
+		if total > 0 {
+			pct = float64(kv.v) * 100 / float64(total)
+		}
+		fmt.Printf("%-20s %10s %7.1f%%\n", kv.k, thousands(kv.v), pct)
+	}
+
+	if len(rep.Adoption) > 0 {
+		fmt.Printf("\nADOPTION, per release, from its own publication day\n")
+		versions := make([]string, 0, len(rep.Adoption))
+		for v := range rep.Adoption {
+			versions = append(versions, v)
+		}
+		sort.Strings(versions)
+		for _, v := range versions {
+			fmt.Printf("  %-12s", v)
+			for _, j := range []string{"J+1", "J+7", "J+30"} {
+				if n, ok := rep.Adoption[v][j]; ok {
+					fmt.Printf("  %s %-6d", j, n)
+				}
+			}
+			fmt.Println()
+		}
+	} else {
+		fmt.Printf("\nADOPTION\n  no point measurable yet: GitHub serves the current counter and never\n" +
+			"  its history, so a J+1, J+7 or J+30 whose day fell before collection\n" +
+			"  started cannot be recovered. Points whose day is still ahead will\n" +
+			"  appear as the snapshots reach them.\n")
+	}
+
+	if len(rep.ActiveOldReleases) > 0 {
+		fmt.Printf("\nOLDER RELEASES STILL BEING DOWNLOADED (last 7 days)\n")
+		for _, a := range rep.ActiveOldReleases {
+			fmt.Printf("  %-12s +%d\n", a.Version, a.Downloads)
+		}
+		fmt.Printf("  A pinned CI, an install script or a third party's image looks like this.\n")
+	}
+
+	for _, w := range rep.Warnings {
+		fmt.Fprintf(os.Stderr, "\nwarning: %s\n", w)
+	}
+}
+
+type kv struct {
+	k string
+	v int
+}
+
+func sortedByValue(m map[string]int) []kv {
+	out := make([]kv, 0, len(m))
+	for k, v := range m {
+		out = append(out, kv{k, v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].v != out[j].v {
+			return out[i].v > out[j].v
+		}
+		return out[i].k < out[j].k
+	})
+	return out
+}
+
+// thousands groups digits with a narrow space, the French convention this
+// project's own documentation uses.
+func thousands(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	lead := len(s) % 3
+	if lead > 0 {
+		b.WriteString(s[:lead])
+	}
+	for i := lead; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}

--- a/tools/metrics/parse_test.go
+++ b/tools/metrics/parse_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// testConfig is feint's own description, so the tests exercise the shipped
+// patterns rather than a convenient invention.
+func testConfig(t *testing.T) *compiled {
+	t.Helper()
+	c, err := LoadConfig("projects/feint.json")
+	if err != nil {
+		t.Fatalf("loading the shipped configuration: %v", err)
+	}
+	return c
+}
+
+func at(day string) *time.Time {
+	p, _ := time.Parse("2006-01-02", day)
+	return &p
+}
+
+// release builds one, with the four binaries plus the four companions this
+// repository actually publishes.
+func release(tag, day string, counts ...int) Release {
+	names := []string{
+		"feint-linux-amd64", "feint-linux-arm64",
+		"feint-darwin-amd64", "feint-darwin-arm64",
+	}
+	r := Release{TagName: tag, PublishedAt: at(day)}
+	for i, n := range names {
+		c := 0
+		if i < len(counts) {
+			c = counts[i]
+		}
+		r.Assets = append(r.Assets, Asset{Name: n, DownloadCount: c})
+	}
+	for _, n := range []string{
+		"checksums.txt", "checksums.txt.cosign.bundle",
+		"sbom.cdx.json", "provenance.intoto.jsonl",
+	} {
+		r.Assets = append(r.Assets, Asset{Name: n, DownloadCount: 999})
+	}
+	return r
+}
+
+// TestOnlyBinariesAreCounted is the whole point of the filter, and the figure
+// it guards was measured: on 2026-09-09 the four binaries totalled 1254 while
+// every asset summed to 2600. Counting the companions would have overstated
+// adoption by 107%.
+func TestOnlyBinariesAreCounted(t *testing.T) {
+	cfg := testConfig(t)
+	snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 10, 1, 2, 3)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Rows) != 4 {
+		t.Fatalf("%d rows, want 4: the companions leaked into the count", len(snap.Rows))
+	}
+	if got := snap.Total(); got != 16 {
+		t.Errorf("total is %d, want 16 (the four binaries); the companions carry 999 each", got)
+	}
+}
+
+// TestAnUnexpectedAssetStopsTheCollection is the refusal that keeps a packaging
+// change from reading as a drop in adoption.
+func TestAnUnexpectedAssetStopsTheCollection(t *testing.T) {
+	cfg := testConfig(t)
+	for _, name := range []string{
+		"feint-windows-amd64",  // an architecture added upstream
+		"feint-linux-riscv64",  // another one
+		"feint_linux_amd64",    // a separator changed
+		"feint-linux-amd64.gz", // the packaging changed
+	} {
+		r := release("v1.0.0", "2026-01-01", 1, 1, 1, 1)
+		r.Assets = append(r.Assets, Asset{Name: name, DownloadCount: 50})
+		_, err := Parse(cfg, []Release{r}, "2026-01-02")
+		if err == nil {
+			t.Errorf("%s was accepted; an asset matching neither list must stop the run", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("the refusal for %s does not name it: %v", name, err)
+		}
+	}
+}
+
+// TestAReleaseCarryingOnlyCompanionsIsRefused is the same defect facing the
+// other way, and it needs a release whose every asset is RECOGNISED, or the
+// unknown-asset guard answers first and this one is never reached. Falsifying
+// caught exactly that: the first version of this test passed with the guard
+// removed, because its asset name matched neither list.
+//
+// The real shape is a release whose binary build failed while the companion
+// steps succeeded: checksums and an SBOM are published, no binary is, and every
+// name is one the configuration knows. Counting on would report the release as
+// downloaded zero times rather than as broken.
+func TestAReleaseCarryingOnlyCompanionsIsRefused(t *testing.T) {
+	cfg := testConfig(t)
+	r := Release{TagName: "v2.0.0", PublishedAt: at("2026-01-01"), Assets: []Asset{
+		{Name: "checksums.txt", DownloadCount: 400},
+		{Name: "sbom.cdx.json", DownloadCount: 12},
+	}}
+	_, err := Parse(cfg, []Release{r}, "2026-01-02")
+	if err == nil {
+		t.Fatal("a release carrying companions and no binary was accepted")
+	}
+	if !strings.Contains(err.Error(), "v2.0.0") {
+		t.Errorf("the refusal does not name the release: %v", err)
+	}
+}
+
+// TestARenamedBinaryIsRefused is the neighbouring case, caught by the other
+// guard: a name matching neither list stops the run.
+func TestARenamedBinaryIsRefused(t *testing.T) {
+	cfg := testConfig(t)
+	r := Release{TagName: "v2.0.0", PublishedAt: at("2026-01-01"), Assets: []Asset{
+		{Name: "feint_v2.0.0_linux_amd64.tar.gz", DownloadCount: 400},
+		{Name: "checksums.txt", DownloadCount: 400},
+	}}
+	if _, err := Parse(cfg, []Release{r}, "2026-01-02"); err == nil {
+		t.Fatal("a release whose binaries were all renamed was accepted, and would have reported a collapse")
+	}
+}
+
+// TestADraftIsSkippedAndAPrereleaseIsKept holds two cases that look alike and
+// are not: a draft's assets are unreachable by anybody but the repository's
+// writers, so its counter measures nothing; a prerelease is public, so it does.
+func TestADraftIsSkippedAndAPrereleaseIsKept(t *testing.T) {
+	cfg := testConfig(t)
+	draft := release("v9.9.9", "2026-01-01", 500, 0, 0, 0)
+	draft.Draft = true
+	pre := release("v2.0.0-rc1", "2026-01-01", 7, 0, 0, 0)
+	pre.Prerelease = true
+
+	snap, err := Parse(cfg, []Release{draft, pre, release("v1.0.0", "2026-01-01", 3, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snap.Total(); got != 10 {
+		t.Errorf("total is %d, want 10 (7 prerelease + 3 release, the draft's 500 excluded)", got)
+	}
+	for _, r := range snap.Rows {
+		if r.Version == "v9.9.9" {
+			t.Error("the draft produced rows")
+		}
+	}
+}
+
+// TestAReleaseWithNoAssetIsHarmless: a tag pushed while the build is still
+// running looks exactly like this, and tomorrow's snapshot carries its binaries.
+func TestAReleaseWithNoAssetIsHarmless(t *testing.T) {
+	cfg := testConfig(t)
+	bare := Release{TagName: "v3.0.0", PublishedAt: at("2026-01-02")}
+	snap, err := Parse(cfg, []Release{bare, release("v1.0.0", "2026-01-01", 5, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatalf("a release still building must not fail the run: %v", err)
+	}
+	if got := snap.Total(); got != 5 {
+		t.Errorf("total is %d, want 5", got)
+	}
+}
+
+// TestAZeroIsAMeasurementAndIsKept: dropping the row would make tomorrow's
+// delta against a non-zero impossible to compute.
+func TestAZeroIsAMeasurementAndIsKept(t *testing.T) {
+	cfg := testConfig(t)
+	snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 0, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Rows) != 4 {
+		t.Fatalf("%d rows, want 4: a zero was dropped", len(snap.Rows))
+	}
+}
+
+// TestNoReleaseAtAllIsRefused: the CSV is append-only, so an empty snapshot
+// would be indistinguishable from a collapse forever after.
+func TestNoReleaseAtAllIsRefused(t *testing.T) {
+	cfg := testConfig(t)
+	if _, err := Parse(cfg, nil, "2026-01-02"); err == nil {
+		t.Fatal("an empty release list was accepted")
+	}
+}
+
+// TestThePlatformComesFromTheNamedGroups proves the split is configuration,
+// not code: a project naming its assets differently only changes its JSON.
+func TestThePlatformComesFromTheNamedGroups(t *testing.T) {
+	cfg := testConfig(t)
+	snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 1, 2, 3, 4)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"feint-linux-amd64":  "linux/amd64",
+		"feint-linux-arm64":  "linux/arm64",
+		"feint-darwin-amd64": "darwin/amd64",
+		"feint-darwin-arm64": "darwin/arm64",
+	}
+	for _, r := range snap.Rows {
+		if got := r.OS + "/" + r.Arch; got != want[r.Asset] {
+			t.Errorf("%s split as %s, want %s", r.Asset, got, want[r.Asset])
+		}
+	}
+}
+
+// TestACounterGoingBackwardsWarnsWithoutFailing. GitHub renumbers when an asset
+// or a release is deleted and recreated, which this project's release procedure
+// does on a botched tag. Failing would stop collection for good; ignoring would
+// publish a delta that is silently wrong.
+func TestACounterGoingBackwardsWarnsWithoutFailing(t *testing.T) {
+	cfg := testConfig(t)
+	before, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 100, 0, 0, 0)}, "2026-01-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 40, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deltas := after.CompareWith(before)
+	if len(after.Warnings) == 0 {
+		t.Fatal("a counter that went from 100 to 40 produced no warning")
+	}
+	if !strings.Contains(after.Warnings[0], "100") || !strings.Contains(after.Warnings[0], "40") {
+		t.Errorf("the warning does not carry both figures: %q", after.Warnings[0])
+	}
+	if d := deltas["v1.0.0\x00feint-linux-amd64"]; d != -60 {
+		t.Errorf("delta is %d, want -60: the figure is reported as measured, not clamped", d)
+	}
+}
+
+// TestADeletedReleaseLeavesTheHistoryAlone: a release that vanishes from the
+// payload must not resurrect as a zero row, which would read as everybody
+// un-downloading it.
+func TestADeletedReleaseLeavesTheHistoryAlone(t *testing.T) {
+	cfg := testConfig(t)
+	before, err := Parse(cfg, []Release{
+		release("v1.0.0", "2026-01-01", 100, 0, 0, 0),
+		release("v1.0.1", "2026-01-01", 50, 0, 0, 0),
+	}, "2026-01-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 110, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after.CompareWith(before)
+	for _, r := range after.Rows {
+		if r.Version == "v1.0.1" {
+			t.Error("the deleted release produced a row in the new snapshot")
+		}
+	}
+	if len(after.Warnings) != 0 {
+		t.Errorf("a deleted release produced a warning about a counter: %v", after.Warnings)
+	}
+}
+
+// TestAConfigurationThatCountsNothingIsRefused: a stale binary_patterns would
+// otherwise classify every asset as unknown, and an empty list would classify
+// none at all.
+func TestAConfigurationThatCountsNothingIsRefused(t *testing.T) {
+	for _, c := range []Config{
+		{Project: "p", Repository: "o/r"},
+		{Repository: "o/r", BinaryPatterns: []string{"^x$"}},
+		{Project: "p", BinaryPatterns: []string{"^x$"}},
+		{Project: "p", Repository: "o/r", BinaryPatterns: []string{"^(unclosed"}},
+	} {
+		if _, err := c.compile(); err == nil {
+			t.Errorf("%+v was accepted", c)
+		}
+	}
+}

--- a/tools/metrics/projects/feint.json
+++ b/tools/metrics/projects/feint.json
@@ -1,0 +1,15 @@
+{
+  "project": "feint",
+  "repository": "stephrobert/feint",
+
+  "binary_patterns": [
+    "^feint-(?P<os>linux|darwin)-(?P<arch>amd64|arm64)$"
+  ],
+
+  "ignore_patterns": [
+    "^checksums\\.txt$",
+    "^checksums\\.txt\\.cosign\\.bundle$",
+    "^sbom\\.cdx\\.json$",
+    "^provenance\\.intoto\\.jsonl$"
+  ]
+}

--- a/tools/metrics/release.go
+++ b/tools/metrics/release.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Asset is the part of a GitHub release asset this tool reads.
+type Asset struct {
+	Name          string `json:"name"`
+	DownloadCount int    `json:"download_count"`
+}
+
+// Release is the part of a GitHub release this tool reads.
+type Release struct {
+	TagName     string     `json:"tag_name"`
+	Draft       bool       `json:"draft"`
+	Prerelease  bool       `json:"prerelease"`
+	PublishedAt *time.Time `json:"published_at"`
+	Assets      []Asset    `json:"assets"`
+}
+
+// Row is one measurement: one asset of one release, on one day.
+type Row struct {
+	Date        string // YYYY-MM-DD, the day the snapshot was taken
+	Version     string
+	Asset       string
+	OS          string
+	Arch        string
+	Downloads   int
+	PublishedAt string // RFC3339, or empty for a release that was never published
+}
+
+// Snapshot is one day's reading of every release.
+type Snapshot struct {
+	Date     string
+	Rows     []Row
+	Warnings []string
+}
+
+// Parse turns the GitHub payload into the rows a snapshot is made of.
+//
+// What it deliberately keeps, against the reflex to filter it out:
+//
+//   - a prerelease and a release whose binaries were downloaded zero times are
+//     both kept. A zero is a measurement, and dropping the row would make the
+//     delta against tomorrow's non-zero impossible to compute.
+//   - a draft is skipped, because its assets are not reachable by anybody but
+//     the repository's writers, so its counter measures nothing about adoption.
+//
+// It refuses, rather than guesses, on two things: an asset that matched no
+// declared pattern (see Classify), and a published release carrying none of the
+// expected binaries.
+//
+// TestADraftIsSkippedAndAPrereleaseIsKept and
+// TestAReleaseCarryingOnlyCompanionsIsRefused fail without this.
+func Parse(cfg *compiled, releases []Release, date string) (*Snapshot, error) {
+	snap := &Snapshot{Date: date}
+	var unknown []string
+
+	for _, r := range releases {
+		if r.Draft {
+			continue
+		}
+		binaries := 0
+		for _, a := range r.Assets {
+			switch cfg.Classify(a.Name) {
+			case KindIgnored:
+				continue
+			case KindUnknown:
+				unknown = append(unknown, fmt.Sprintf("%s/%s", r.TagName, a.Name))
+				continue
+			}
+			binaries++
+			goos, arch := cfg.Platform(a.Name)
+			published := ""
+			if r.PublishedAt != nil {
+				published = r.PublishedAt.UTC().Format(time.RFC3339)
+			}
+			snap.Rows = append(snap.Rows, Row{
+				Date:        date,
+				Version:     r.TagName,
+				Asset:       a.Name,
+				OS:          goos,
+				Arch:        arch,
+				Downloads:   a.DownloadCount,
+				PublishedAt: published,
+			})
+		}
+		// A release with no asset at all is a real and harmless state: a tag
+		// pushed while the build is still running looks exactly like this, and
+		// tomorrow's snapshot will carry its binaries. What is not harmless is
+		// a release carrying assets of which none is a binary, because that is
+		// the packaging change this tool exists to notice.
+		if binaries == 0 && len(r.Assets) > 0 {
+			return nil, fmt.Errorf(
+				"release %s carries %d asset(s) and not one of them matched a binary pattern; "+
+					"either the release workflow renamed the binaries or binary_patterns is stale, "+
+					"and counting on regardless would report a drop in adoption that never happened",
+				r.TagName, len(r.Assets))
+		}
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf(
+			"%d asset(s) matched neither binary_patterns nor ignore_patterns: %s. "+
+				"Add each one to whichever list it belongs to; an asset this tool does not "+
+				"recognise is a decision for a human, not a silent zero",
+			len(unknown), strings.Join(unknown, ", "))
+	}
+	if len(snap.Rows) == 0 {
+		return nil, fmt.Errorf("no published release carries a binary, so there is nothing to measure")
+	}
+
+	sort.Slice(snap.Rows, func(i, j int) bool {
+		if snap.Rows[i].Version != snap.Rows[j].Version {
+			return snap.Rows[i].Version < snap.Rows[j].Version
+		}
+		return snap.Rows[i].Asset < snap.Rows[j].Asset
+	})
+	return snap, nil
+}
+
+// Total is the figure every report leads with.
+func (s *Snapshot) Total() int {
+	n := 0
+	for _, r := range s.Rows {
+		n += r.Downloads
+	}
+	return n
+}
+
+// key identifies one asset of one version across snapshots, which is what a
+// delta is computed on.
+func (r Row) key() string { return r.Version + "\x00" + r.Asset }
+
+// CompareWith records what moved since the previous snapshot, and warns rather
+// than fails when a counter went backwards.
+//
+// A counter that decreases is not corruption and must not stop the collection:
+// GitHub renumbers when an asset or a whole release is deleted and recreated,
+// which the release procedure here does on a botched tag. But it silently
+// breaks every delta computed across that day, so it is reported.
+//
+// TestACounterGoingBackwardsWarnsWithoutFailing fails without this.
+func (s *Snapshot) CompareWith(previous *Snapshot) map[string]int {
+	deltas := map[string]int{}
+	if previous == nil {
+		return deltas
+	}
+	before := map[string]int{}
+	for _, r := range previous.Rows {
+		before[r.key()] = r.Downloads
+	}
+	for _, r := range s.Rows {
+		was, seen := before[r.key()]
+		if !seen {
+			continue
+		}
+		if r.Downloads < was {
+			s.Warnings = append(s.Warnings, fmt.Sprintf(
+				"%s/%s went from %d to %d. GitHub renumbers when an asset or a release is "+
+					"deleted and recreated; the delta across this day is not usable",
+				r.Version, r.Asset, was, r.Downloads))
+		}
+		deltas[r.key()] = r.Downloads - was
+	}
+	return deltas
+}

--- a/tools/metrics/report.go
+++ b/tools/metrics/report.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"sort"
+	"strconv"
+	"time"
+)
+
+// Report is every figure the CLI prints and latest.json carries.
+type Report struct {
+	GeneratedAt          string         `json:"generated_at"`
+	Project              string         `json:"project"`
+	TotalBinaryDownloads int            `json:"total_binary_downloads"`
+	LatestRelease        string         `json:"latest_release"`
+	Platforms            map[string]int `json:"platforms"`
+	Versions             map[string]int `json:"versions"`
+
+	// Recent are the deltas over the trailing windows. A window with no
+	// snapshot old enough to close it is absent from the map rather than
+	// present at zero: "nothing was downloaded in 30 days" and "this tool has
+	// not been collecting for 30 days" are opposite facts, and a zero says the
+	// first while meaning the second.
+	Recent map[string]int `json:"recent,omitempty"`
+
+	// Adoption is J+1 / J+7 / J+30 per release, and it can only ever exist for
+	// releases published after the first snapshot: GitHub serves the current
+	// counter and never its history, so the curve for a release cut before this
+	// tool existed is not late, it is unrecoverable.
+	Adoption map[string]map[string]int `json:"adoption,omitempty"`
+
+	// ActiveOldReleases names releases that are not the newest and still take
+	// downloads. Not an anomaly: a pinned CI, an install script or a third
+	// party's image looks exactly like this, and that is worth seeing.
+	ActiveOldReleases []ActiveRelease `json:"active_old_releases,omitempty"`
+
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// ActiveRelease is one older release still being consumed.
+type ActiveRelease struct {
+	Version   string `json:"version"`
+	Downloads int    `json:"downloads_in_window"`
+	Days      int    `json:"window_days"`
+}
+
+// windows are the trailing deltas the report publishes.
+var windows = map[string]int{"downloads_1d": 1, "downloads_7d": 7, "downloads_30d": 30}
+
+// Build computes every figure from the history alone, so the numbers a report
+// prints can be recomputed by anybody holding the CSV.
+func Build(project string, h *History, now time.Time) *Report {
+	latest := h.Latest()
+	rep := &Report{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Project:     project,
+		Platforms:   map[string]int{},
+		Versions:    map[string]int{},
+	}
+	if latest == nil {
+		return rep
+	}
+
+	rep.TotalBinaryDownloads = latest.Total()
+	for _, r := range latest.Rows {
+		rep.Versions[r.Version] += r.Downloads
+		if r.OS != "" || r.Arch != "" {
+			rep.Platforms[r.OS+"-"+r.Arch] += r.Downloads
+		} else {
+			rep.Platforms[r.Asset] += r.Downloads
+		}
+	}
+	rep.LatestRelease = newestPublished(latest)
+	rep.Warnings = latest.Warnings
+
+	rep.Recent = trailing(h, latest, now)
+	rep.Adoption = adoption(h)
+	rep.ActiveOldReleases = activeOld(h, latest, rep.LatestRelease, now)
+	return rep
+}
+
+// newestPublished is the release with the most recent publication date, which
+// is not the same as the largest tag: 0.9.0 sorts after 0.13.0 as a string.
+func newestPublished(s *Snapshot) string {
+	best, bestAt := "", ""
+	for _, r := range s.Rows {
+		if r.PublishedAt > bestAt {
+			best, bestAt = r.Version, r.PublishedAt
+		}
+	}
+	return best
+}
+
+// trailing computes each window's delta, and omits a window the history is too
+// short to close.
+func trailing(h *History, latest *Snapshot, now time.Time) map[string]int {
+	out := map[string]int{}
+	for name, days := range windows {
+		cutoff := now.UTC().AddDate(0, 0, -days).Format("2006-01-02")
+		var base *Snapshot
+		for _, d := range h.SortedDates() {
+			if d <= cutoff {
+				base = h.Dates[d]
+			}
+		}
+		if base == nil || base.Date == latest.Date {
+			continue
+		}
+		out[name] = latest.Total() - base.Total()
+	}
+	return out
+}
+
+// staleDays is how far past a J+N date a snapshot may sit and still answer for
+// it. A daily job that missed a run stays usable; a month-long gap does not,
+// because the counter kept climbing in between and the figure would be a later
+// day's reading wearing J+7's label.
+const staleDays = 2
+
+// adoption reads each release's cumulative counter at its own J+1, J+7 and J+30.
+//
+// There is nothing to subtract, and getting that wrong is the easy mistake: a
+// release's counter starts at zero the moment it is published, so its cumulative
+// value on day N IS its adoption at J+N. An earlier version of this function
+// subtracted the reading at the origin snapshot, which silently erased whatever
+// the release earned before the first snapshot that saw it.
+//
+// What genuinely cannot be recovered is a J+N whose date fell before this tool
+// ever ran: GitHub serves the current counter and never its history. For a
+// release published on 2026-09-01 with collection starting on 2026-09-10, J+1
+// and J+7 are gone for good while J+30 is simply a snapshot away. So the
+// availability is decided per point, not per release.
+//
+// TestAdoptionOmitsOnlyThePointsThatFellBeforeCollection fails without this.
+func adoption(h *History) map[string]map[string]int {
+	dates := h.SortedDates()
+	if len(dates) == 0 {
+		return nil
+	}
+	first := dates[0]
+
+	published := map[string]string{}
+	for _, d := range dates {
+		for _, r := range h.Dates[d].Rows {
+			if r.PublishedAt != "" && published[r.Version] == "" {
+				published[r.Version] = r.PublishedAt[:10]
+			}
+		}
+	}
+
+	out := map[string]map[string]int{}
+	for version, day := range published {
+		curve := map[string]int{}
+		for _, n := range []int{1, 7, 30} {
+			target := addDays(day, n)
+			if target < first {
+				// The instant passed before anybody was looking.
+				continue
+			}
+			at := snapshotOnOrAfter(h, target)
+			if at == nil || at.Date > addDays(target, staleDays) {
+				continue
+			}
+			curve["J+"+strconv.Itoa(n)] = versionTotal(at, version)
+		}
+		if len(curve) > 0 {
+			out[version] = curve
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// activeOld names releases other than the newest that still moved in the last
+// 7 days, busiest first.
+func activeOld(h *History, latest *Snapshot, newest string, now time.Time) []ActiveRelease {
+	const days = 7
+	cutoff := now.UTC().AddDate(0, 0, -days).Format("2006-01-02")
+	var base *Snapshot
+	for _, d := range h.SortedDates() {
+		if d <= cutoff {
+			base = h.Dates[d]
+		}
+	}
+	if base == nil || base.Date == latest.Date {
+		return nil
+	}
+	var out []ActiveRelease
+	for _, r := range latest.Rows {
+		if r.Version == newest {
+			continue
+		}
+		if d := versionTotal(latest, r.Version) - versionTotal(base, r.Version); d > 0 {
+			if !containsVersion(out, r.Version) {
+				out = append(out, ActiveRelease{Version: r.Version, Downloads: d, Days: days})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Downloads > out[j].Downloads })
+	return out
+}
+
+func containsVersion(list []ActiveRelease, v string) bool {
+	for _, a := range list {
+		if a.Version == v {
+			return true
+		}
+	}
+	return false
+}
+
+func versionTotal(s *Snapshot, version string) int {
+	n := 0
+	for _, r := range s.Rows {
+		if r.Version == version {
+			n += r.Downloads
+		}
+	}
+	return n
+}
+
+func snapshotOnOrAfter(h *History, date string) *Snapshot {
+	for _, d := range h.SortedDates() {
+		if d >= date {
+			return h.Dates[d]
+		}
+	}
+	return nil
+}
+
+func addDays(date string, n int) string {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return date
+	}
+	return t.AddDate(0, 0, n).Format("2006-01-02")
+}

--- a/tools/metrics/store.go
+++ b/tools/metrics/store.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+)
+
+// header is the CSV's first line, and the shape every reader depends on.
+var header = []string{"date", "version", "asset", "os", "arch", "downloads", "published_at"}
+
+// History is every snapshot ever taken, keyed by date.
+type History struct {
+	Dates map[string]*Snapshot
+}
+
+// ReadHistory loads the append-only CSV. A missing file is the first run, not
+// an error.
+func ReadHistory(path string) (*History, error) {
+	h := &History{Dates: map[string]*Snapshot{}}
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return h, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	for i, rec := range rows {
+		if i == 0 {
+			if len(rec) != len(header) || rec[0] != header[0] {
+				return nil, fmt.Errorf("%s: unexpected header %v, want %v", path, rec, header)
+			}
+			continue
+		}
+		if len(rec) != len(header) {
+			return nil, fmt.Errorf("%s line %d: %d fields, want %d", path, i+1, len(rec), len(header))
+		}
+		n, err := strconv.Atoi(rec[5])
+		if err != nil {
+			return nil, fmt.Errorf("%s line %d: downloads %q: %w", path, i+1, rec[5], err)
+		}
+		date := rec[0]
+		if h.Dates[date] == nil {
+			h.Dates[date] = &Snapshot{Date: date}
+		}
+		h.Dates[date].Rows = append(h.Dates[date].Rows, Row{
+			Date: date, Version: rec[1], Asset: rec[2], OS: rec[3], Arch: rec[4],
+			Downloads: n, PublishedAt: rec[6],
+		})
+	}
+	return h, nil
+}
+
+// SortedDates answers every snapshot date, oldest first.
+func (h *History) SortedDates() []string {
+	out := make([]string, 0, len(h.Dates))
+	for d := range h.Dates {
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Latest is the most recent snapshot, or nil when there is none.
+func (h *History) Latest() *Snapshot {
+	d := h.SortedDates()
+	if len(d) == 0 {
+		return nil
+	}
+	return h.Dates[d[len(d)-1]]
+}
+
+// Before answers the most recent snapshot strictly older than date.
+func (h *History) Before(date string) *Snapshot {
+	var best string
+	for _, d := range h.SortedDates() {
+		if d < date {
+			best = d
+		}
+	}
+	if best == "" {
+		return nil
+	}
+	return h.Dates[best]
+}
+
+// Append writes one snapshot at the end of the CSV.
+//
+// It refuses a date the file already carries rather than appending a second
+// one. Two snapshots for one day would double every figure a naive sum
+// produces and make the delta for that day read as zero, and the workflow can
+// legitimately run twice in a day: once on its schedule and once by hand
+// through workflow_dispatch.
+//
+// TestASecondSnapshotForTheSameDayIsRefused fails without this.
+func Append(path string, snap *Snapshot) error {
+	existing, err := ReadHistory(path)
+	if err != nil {
+		return err
+	}
+	if _, already := existing.Dates[snap.Date]; already {
+		return fmt.Errorf("%s already carries a snapshot for %s", path, snap.Date)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+
+	fresh := len(existing.Dates) == 0
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // a committed, non-secret metrics history
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	w := csv.NewWriter(f)
+	if fresh {
+		if err := w.Write(header); err != nil {
+			return err
+		}
+	}
+	for _, r := range snap.Rows {
+		if err := w.Write([]string{
+			r.Date, r.Version, r.Asset, r.OS, r.Arch,
+			strconv.Itoa(r.Downloads), r.PublishedAt,
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}

--- a/tools/metrics/store_test.go
+++ b/tools/metrics/store_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestASecondSnapshotForTheSameDayIsRefused. The workflow can legitimately run
+// twice in a day, once on its schedule and once through workflow_dispatch, and
+// the CSV is append-only: a second row set would double every naive sum and
+// make that day's delta read as zero.
+func TestASecondSnapshotForTheSameDayIsRefused(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "d.csv")
+	cfg := testConfig(t)
+	snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 5, 0, 0, 0)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Append(path, snap); err != nil {
+		t.Fatal(err)
+	}
+	if err := Append(path, snap); err == nil {
+		t.Fatal("a second snapshot for 2026-01-02 was appended")
+	}
+	h, err := ReadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.Dates["2026-01-02"].Total(); got != 5 {
+		t.Errorf("total is %d, want 5: the refused append still wrote rows", got)
+	}
+}
+
+// TestTheCSVRoundTrips holds the format the site and any future reader depend on.
+func TestTheCSVRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "d.csv")
+	cfg := testConfig(t)
+	snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 7, 1, 2, 3)}, "2026-01-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Append(path, snap); err != nil {
+		t.Fatal(err)
+	}
+	h, err := ReadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back := h.Dates["2026-01-02"]
+	if len(back.Rows) != len(snap.Rows) {
+		t.Fatalf("%d rows read, %d written", len(back.Rows), len(snap.Rows))
+	}
+	for i := range snap.Rows {
+		if back.Rows[i] != snap.Rows[i] {
+			t.Errorf("row %d: read %+v, wrote %+v", i, back.Rows[i], snap.Rows[i])
+		}
+	}
+}
+
+// TestAMissingFileIsTheFirstRun, not an error.
+func TestAMissingFileIsTheFirstRun(t *testing.T) {
+	h, err := ReadHistory(filepath.Join(t.TempDir(), "absent.csv"))
+	if err != nil {
+		t.Fatalf("a missing file must read as an empty history: %v", err)
+	}
+	if len(h.Dates) != 0 || h.Latest() != nil {
+		t.Error("an absent file produced snapshots")
+	}
+}
+
+// TestPaginationWalksEveryPage covers the >100 releases case the brief names.
+func TestPaginationWalksEveryPage(t *testing.T) {
+	pages := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		page := r.URL.Query().Get("page")
+		var batch []Release
+		switch page {
+		case "1", "2":
+			for i := 0; i < 100; i++ {
+				batch = append(batch, release(fmt.Sprintf("v0.%s.%d", page, i), "2026-01-01", 1, 0, 0, 0))
+			}
+		default:
+			batch = nil // the empty page ends the walk
+		}
+		_ = json.NewEncoder(w).Encode(batch)
+	}))
+	defer srv.Close()
+
+	old := apiBase
+	apiBase = srv.URL
+	defer func() { apiBase = old }()
+
+	got, err := FetchReleases("o/r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 200 {
+		t.Errorf("%d releases, want 200 across two full pages", len(got))
+	}
+	if pages != 3 {
+		t.Errorf("%d requests, want 3 (two full pages then the empty one)", pages)
+	}
+}
+
+// TestAnUnavailableAPIFailsRatherThanWritingAPartialSnapshot. The CSV is
+// append-only, so a partial read committed today is indistinguishable from a
+// collapse in downloads forever after.
+func TestAnUnavailableAPIFailsRatherThanWritingAPartialSnapshot(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "1" {
+			_ = json.NewEncoder(w).Encode([]Release{release("v1.0.0", "2026-01-01", 1, 0, 0, 0)})
+			return
+		}
+		http.Error(w, `{"message":"Server Error"}`, http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	old := apiBase
+	apiBase = srv.URL
+	defer func() { apiBase = old }()
+
+	got, err := FetchReleases("o/r")
+	if err == nil {
+		t.Fatalf("a 503 on page 2 was accepted, returning %d releases", len(got))
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("the error does not carry the status: %v", err)
+	}
+}
+
+// TestTrailingWindowsStayAbsentUntilTheyClose. "Nothing was downloaded in 30
+// days" and "this tool has not been collecting for 30 days" are opposite facts,
+// and a zero says the first while meaning the second.
+func TestTrailingWindowsStayAbsentUntilTheyClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "d.csv")
+	cfg := testConfig(t)
+	for i, day := range []string{"2026-03-01", "2026-03-03"} {
+		snap, err := Parse(cfg, []Release{release("v1.0.0", "2026-01-01", 100+i*10, 0, 0, 0)}, day)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := Append(path, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h, err := ReadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now, _ := time.Parse("2006-01-02", "2026-03-03")
+	rep := Build("feint", h, now)
+
+	if _, ok := rep.Recent["downloads_30d"]; ok {
+		t.Error("a 30-day window closed on a 2-day history")
+	}
+	if got, ok := rep.Recent["downloads_1d"]; !ok || got != 10 {
+		t.Errorf("downloads_1d is %d (present: %v), want 10", got, ok)
+	}
+}


### PR DESCRIPTION
# Summary

Measure how much of what this project publishes is actually fetched, from the
only figure GitHub serves: an asset's `download_count`.

`docs/adoption.md` counts decisions somebody made — configurations that apply,
issues opened by strangers, a provider that mentions the project. This counts
something weaker, and it lives on its own page so the two never get read as one:
**how many times a binary was downloaded**.

A daily workflow reads every release asset, keeps the four that are the
software, and appends a row per asset to an append-only CSV.

## What was measured before anything was built

Every figure below is a reading, not a claim.

| | |
|---|---|
| the four binaries, together | **1 254** (2026-09-09), 1 260 the next day |
| every asset summed | **2 600** — the mistake the filter exists to prevent, +107% |
| `checksums.txt` alone | **1 264** |
| `linux-amd64` share | **96.3%** |

`checksums.txt` is fetched slightly **more** often than every binary combined.
Nobody reads a checksum file for pleasure: that is an install script verifying
before it runs, which is what `setup-feint` does. With `linux-amd64` at 96.3%,
the shape of this traffic is a fleet of runners, not a crowd of laptops.

That is information rather than noise, and it is also the reason this page never
writes "1 254 users".

## Three decisions worth the diff

**The filter is two explicit lists, and an asset matching neither stops the
collection.** A permissive filter would report a smaller number the day the
release workflow adds `feint-windows-amd64` or renames an asset, and a smaller
number reads exactly like a drop in adoption. This is what `Declined()` does for
an unserved operation, for the same reason.

**J+1 / J+7 / J+30 availability is decided per point, not per release.** GitHub
serves the current counter and never its history, so v0.12.1's J+1 and J+7 are
unrecoverable while its J+30 is simply a snapshot away. A first implementation
subtracted a reading at an "origin" snapshot, which was wrong twice over: a
release's counter starts at zero when it is published, so its cumulative value
on day N *is* its adoption at J+N, and subtracting erased whatever it earned
before the first snapshot that saw it. A test caught it.

**The data lives on the orphan `metrics` branch.** `main`'s ruleset carries
`pull_request` and `required_status_checks`, so a daily push to `main` is
refused outright, and a pull request a day to land a row of numbers would be
worse. `drift.yml`'s push mechanism is followed exactly, `persist-credentials:
false` included.

## Falsified

Six mutations, each one compiling and turning its named test red.

One of them earned its keep: `TestARenamedBinaryIsRefusedRatherThanCountedAsZero`
passed with its guard removed, because the asset name it used matched neither
list and the *unknown-asset* guard answered first. The test was passing for the
wrong reason. It was split into the two cases it was conflating, and the guard
under test now has a release whose every asset is recognised and none is a
binary — the shape of a release whose binary build failed while its companion
steps succeeded.

## Two deviations from the brief, both forced by this repository

- **Configuration is JSON, not YAML.** Rule 6 admits no dependency and the
  standard library has no YAML parser; a hand-rolled subset would be a
  dependency written in-house. Every other configured artefact here is already
  JSON.
- **Snapshots go to a branch, not to `main`.** See above.

## What was deliberately not built

No telemetry. feint calls nobody, generates no identifier, reads no IP, hostname
or repository. Everything here is read from outside, from a counter GitHub
already publishes.

The collector is **not** part of the feint binary, for the same reason: feint
emulates clouds, this reads a release page.

## Type of change

- [x] Chore / tooling
- [x] Documentation

## Checklist

### Always

- [x] `mise run check` passes, and `mise run prepush` in full
- [x] No new external Go dependency — standard library only (`net/http`,
      `encoding/json`, `encoding/csv`, `regexp`)
- [x] `internal/core` still knows no provider — untouched; the collector lives
      in `tools/metrics/`, beside `tools/conformance`, which already carries Go
- [x] Nothing in the diff could be written identically for another provider —
      it is not provider code; it is deliberately generic across *projects*,
      which is the point (`tools/metrics/projects/*.json`)
- [x] `mise run testplan` was run. **`conformance` was not played, and this
      says so rather than leaving the box blank**: this change adds no route, no
      handler and no response shape. It adds one Go package under `tools/`, one
      workflow, one documentation page and two mise tasks. No client-visible
      behaviour of the emulator differs before and after, so a conformance leg
      would re-prove the previous commit.

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] N/A on `mise run conformance`, for the reason stated just above
- [x] Every name in the diff comes from a measurement: the asset names from
      `.github/workflows/release.yml`'s build matrix and `files:` list, and the
      figures from the GitHub API, read and re-read a day apart

### When a route is added or changed

N/A — none.

### When behaviour a client can observe changes

N/A — none does.

### When `.github/workflows/` is touched

- [x] Every action pinned to a full 40-character SHA with a `# vX.Y.Z` comment
- [x] `step-security/harden-runner` is the job's first step
- [x] `permissions:` least-privilege — `contents: read` at the top,
      `contents: write` only on the one job that writes, and only to a branch
      that carries no code
- [x] No job renamed
- [x] The exit-code contract holds: nothing pipes a gate through `tee`.
      `actionlint` is clean and `zizmor` reports **0** findings

### When a machine runtime is involved

N/A.

## Before this can run

The orphan `metrics` branch has to exist, seeded with the first snapshot. It is
prepared locally and is **not** pushed with this pull request; say the word and
it goes up, or the first `workflow_dispatch` can seed it after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
