### PR TITLE
fix(metrics): the snapshot job authenticates its push, which the first run proved it could not

### DIFF
--- a/.github/workflows/adoption-metrics.yml
+++ b/.github/workflows/adoption-metrics.yml
@@ -86,6 +86,14 @@ jobs:
         run: |
           set -euo pipefail
           cd data
+          # persist-credentials: false above means this clone carries no
+          # credential, which is the point: a token left in .git/config is what
+          # zizmor's artipacked audit flags. It also means `git push` has nothing
+          # to authenticate with, and the first run failed exactly there, after
+          # writing the commit — `could not read Username for https://github.com`.
+          # This installs gh as git's credential helper for the length of the
+          # job, so the token lives in the environment and never on disk.
+          gh auth setup-git
           git config user.name  'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add metrics


### PR DESCRIPTION
# Summary

The first run of `adoption-metrics.yml` collected the snapshot, wrote the commit, and died on the last line:

```
[metrics 4e038c5] chore(metrics): update adoption metrics 2026-09-11
 2 files changed, 100 insertions(+), 13 deletions(-)
fatal: could not read Username for 'https://github.com': No such device or address
```

The collector was never the problem. `persist-credentials: false` leaves the data checkout with no credential — which is deliberate, a token in `.git/config` is what zizmor's `artipacked` audit flags — and it also leaves `git push` with nothing to authenticate with.

`gh auth setup-git` installs gh as git's credential helper for the length of the job. The token stays in the environment and reaches no file, so the audit stays clean and the push works.

## What this corrects in my own reasoning

`drift.yml` pushes a branch with `persist-credentials: false` too, and I copied its arrangement on the assumption that the runner provides a helper. It does not — at least not one this job inherits. **This was found by running the workflow rather than by reading it**, which is the only reason it is fixed now instead of failing silently every night at 04:17.

## Type of change

- [x] Bug fix
- [x] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, and `mise run prepush` in full
- [x] No new external Go dependency — no Go changed
- [x] `internal/core` still knows no provider — untouched
- [x] Nothing in the diff could be written identically for another provider — it is workflow plumbing
- [x] `mise run testplan` was run. It names no run for a workflow-only diff, and `conformance` is **not** played: no route, no handler, no response shape changed. Eight lines of YAML and a comment.

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] N/A on `mise run conformance`, for the reason just above
- [x] No field name is involved

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

N/A.

### When `.github/workflows/` is touched

- [x] Every action pinned to a full 40-character SHA with a `# vX.Y.Z` comment — unchanged by this diff
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` least-privilege — unchanged
- [x] No job renamed
- [x] The exit-code contract holds. `actionlint` clean, `zizmor` **0** findings

### When a machine runtime is involved

N/A.

## Verification

The workflow will be dispatched by hand once this merges, and the result read rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)