### PR TITLE
fix(drift): a pull request refused by repository policy is not a red night

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -266,10 +266,50 @@ jobs:
           # which is the normal case for triage.
           git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" || true
           git push --force-with-lease origin "$branch"
-          if [ -z "$(gh pr list --head "$branch" --json number --jq '.[0].number')" ]; then
-            gh pr create --head "$branch" --title "chore(drift): upstream API surface moved" \
-              --body "The nightly scan found a change in the upstream SDK surface. Review the baseline diff: each added entry is an operation that appeared upstream and has not been triaged yet. Implement it, or add it to the pack's Declined list."
+          if [ -n "$(gh pr list --head "$branch" --json number --jq '.[0].number')" ]; then
+            echo "a pull request is already open on $branch; the push above updated it"
+            exit 0
           fi
+
+          # This repository deliberately withholds pull-request creation from
+          # Actions: `can_approve_pull_request_reviews` is false and the default
+          # workflow permission is `read`, which is a hardening choice the
+          # Scorecard reads. GitHub then answers createPullRequest with
+          # "GitHub Actions is not permitted to create or approve pull requests".
+          #
+          # That is a POLICY answer, not a failure of the scan, and failing the
+          # job on it turned an ordinary event — Scaleway ships around 34 commits
+          # a month on its surface — into a red night, twice in September 2026.
+          # A gate that is red on the normal case is a gate people stop reading,
+          # which is the failure mode CLAUDE.md names.
+          #
+          # So this one answer is reported and tolerated. The branch is pushed
+          # either way, the issue job carries the triage, and the summary says
+          # where the diff is. EVERY OTHER error still fails the job: a token
+          # without scope, a rate limit, a branch that does not exist are real
+          # problems and must not hide behind this.
+          if out=$(gh pr create --head "$branch" \
+              --title "chore(drift): upstream API surface moved" \
+              --body "The nightly scan found a change in the upstream SDK surface. Review the baseline diff: each added entry is an operation that appeared upstream and has not been triaged yet. Implement it, or add it to the pack's Declined list." 2>&1); then
+            echo "$out"
+            exit 0
+          fi
+          echo "$out" >&2
+          case "$out" in
+            *"not permitted to create or approve pull requests"*)
+              {
+                printf '### The drift branch is pushed, the pull request is not\n\n'
+                printf 'This repository does not let Actions open pull requests, which is a\n'
+                printf 'deliberate hardening choice. The refreshed baseline is on branch %s\n\n' "$branch"
+                printf 'Open it by hand: https://github.com/%s/compare/main...%s?expand=1\n\n' \
+                  "$GITHUB_REPOSITORY" "$branch"
+                printf 'The drift issue carries the triage itself.\n'
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "the pull request was refused by repository policy; the branch and the issue carry the signal"
+              exit 0
+              ;;
+          esac
+          exit 1
 
   # An issue rather than only a pull request, because the two say different
   # things. The pull request carries the mechanical part — a refreshed baseline,


### PR DESCRIPTION
# Summary

The nightly drift scan has been failing on **every** drift since the repository hardened its Actions permissions. The scan itself works; the last step does not:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

That is a **policy answer**, not a failure. The repository sets:

```
default_workflow_permissions      : read
can_approve_pull_request_reviews  : false
```

which is a deliberate hardening choice the Scorecard reads, and it is not going to change for this.

## Why it mattered

Scaleway ships around 34 commits a month on its surface, so **a drift is the normal case, and the normal case was red**. Nights of 9 and 10 September both failed this way. A gate red on the normal case is a gate people stop reading, which is the failure mode `CLAUDE.md` names in as many words.

It also left `chore/upstream-drift` pushed with no pull request and no explanation anywhere. That is how this was found: somebody asked what that branch was doing on origin.

The signal was never fully lost — `Open the drift issue` succeeded and #752 was opened — but the red night was noise on top of a mechanism that had worked.

## What changes

The branch is pushed either way. That **one** answer is reported in the step summary with the compare link to open by hand, and the job stays green. The issue job carries the triage itself.

**Every other error still fails the job.** A token without scope, a rate limit, a branch that does not exist are real problems and must not hide behind this.

## Verified rather than asserted

The decision was driven with a stub `gh` over four cases:

| case | exit | |
|---|---|---|
| created normally | 0 | |
| **refused by policy** | 0 | and the summary carries the compare link |
| a pull request is already open | 0 | |
| **a rate limit** | **1** | the negative witness — without it, tolerating everything would pass the other three |

`actionlint` and `zizmor` both pass. One honest limit: this is a one-off verification with a stub, not a permanent gate — the repository has no harness for workflow logic and this change did not seem worth inventing one.

## Type of change

- [x] Bug fix
- [x] Chore / tooling

## Checklist

### Always

- [x] `mise run check` passes, and `mise run prepush` in full
- [x] No new external Go dependency — no Go changed
- [x] `internal/core` still knows no provider — untouched
- [x] Nothing in the diff could be written identically for another provider — it is workflow plumbing
- [x] `mise run testplan` was run. It names no run for a workflow-only diff, and `conformance` is **not** played: no route, no handler, no response shape changed.

### When a model wrote a substantive part of this

- [x] An `Assisted-by:` trailer names the tool and the model version
- [ ] N/A on `mise run conformance`, for the reason just above
- [x] No field name is involved

### When a route is added or changed

N/A.

### When behaviour a client can observe changes

N/A.

### When `.github/workflows/` is touched

- [x] Every action pinned to a full 40-character SHA — unchanged by this diff
- [x] `step-security/harden-runner` is the job's first step — unchanged
- [x] `permissions:` least-privilege — unchanged
- [x] No job renamed
- [x] The exit-code contract holds, and tightening it is the whole point of this change

### When a machine runtime is involved

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)